### PR TITLE
fix: init 命令支持个人 Access Token 认证

### DIFF
--- a/.changeset/fix-init-token-support.md
+++ b/.changeset/fix-init-token-support.md
@@ -1,0 +1,8 @@
+---
+'octo-cli': patch
+---
+
+fix: init 命令支持个人 Access Token 认证
+
+- init 凭据检查现在同时识别 config.token 和 OCTOPUS_TOKEN 环境变量
+- 错误提示更新为推荐 `login --token` 方式

--- a/src/init.ts
+++ b/src/init.ts
@@ -258,8 +258,7 @@ export function runInit(targetDir?: string): void {
   let hasCredentials = false;
   try {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    hasCredentials =
-      !!(config.app_id && config.app_secret) || !!config.token;
+    hasCredentials = !!(config.app_id && config.app_secret) || !!config.token;
   } catch {
     // no config file
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -258,20 +258,20 @@ export function runInit(targetDir?: string): void {
   let hasCredentials = false;
   try {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    hasCredentials = !!(config.app_id && config.app_secret);
+    hasCredentials =
+      !!(config.app_id && config.app_secret) || !!config.token;
   } catch {
     // no config file
   }
   hasCredentials =
     hasCredentials ||
-    !!(process.env.OCTOPUS_APP_ID && process.env.OCTOPUS_APP_SECRET);
+    !!(process.env.OCTOPUS_APP_ID && process.env.OCTOPUS_APP_SECRET) ||
+    !!process.env.OCTOPUS_TOKEN;
 
   if (!hasCredentials) {
     console.error('Error: Not logged in. Run this first:');
     console.error('');
-    console.error(
-      '  npx octo-cli login --app-id <APP_ID> --app-secret <APP_SECRET>'
-    );
+    console.error('  npx octo-cli login --token <TOKEN>');
     console.error('');
     console.error(
       'The init command needs Octopus API access so the agent can query'


### PR DESCRIPTION
## Summary

- `init` 命令的凭据检查之前只识别 `app_id + app_secret`，现在同时支持 `config.token` 和 `OCTOPUS_TOKEN` 环境变量
- 错误提示更新为推荐 `login --token` 方式

## Test plan

- [ ] `octo login --token <TOKEN>` 后执行 `octo init`，应正常通过凭据检查
- [ ] 设置 `OCTOPUS_TOKEN` 环境变量后执行 `octo init`，应正常通过
- [ ] 未配置任何凭据时 `octo init` 报错提示 `login --token`