### PR TITLE
fix: --from/--to 参数被 --last 默认值覆盖

### DIFF
--- a/.changeset/fix-time-range-priority.md
+++ b/.changeset/fix-time-range-priority.md
@@ -1,0 +1,8 @@
+---
+'octo-cli': patch
+---
+
+修复 --from/--to 参数被 --last 默认值覆盖的问题
+
+- resolveTimeRange 中 --from/--to 优先级提升至 --last 之前
+- 修复 alerts search、issues search、trace search 等 11 个命令的时间范围参数失效问题

--- a/src/time.test.ts
+++ b/src/time.test.ts
@@ -58,4 +58,14 @@ describe('resolveTimeRange', () => {
     expect(from).toBe(new Date('2024-01-01T00:00:00Z').getTime());
     expect(to).toBe(new Date('2024-01-01T01:00:00Z').getTime());
   });
+
+  it('--from/--to takes precedence over --last', () => {
+    const { from, to } = resolveTimeRange({
+      last: '1h',
+      from: '2024-06-01T00:00:00Z',
+      to: '2024-06-01T23:59:59Z',
+    });
+    expect(from).toBe(new Date('2024-06-01T00:00:00Z').getTime());
+    expect(to).toBe(new Date('2024-06-01T23:59:59Z').getTime());
+  });
 });

--- a/src/time.ts
+++ b/src/time.ts
@@ -29,15 +29,15 @@ export function resolveTimeRange(opts: {
 }): { from: number; to: number } {
   const now = Date.now();
 
-  if (opts.last) {
-    const ms = parseDuration(opts.last);
-    return { from: now - ms, to: now };
-  }
-
   if (opts.from) {
     const from = parseTimestamp(opts.from);
     const to = opts.to ? parseTimestamp(opts.to) : now;
     return { from, to };
+  }
+
+  if (opts.last) {
+    const ms = parseDuration(opts.last);
+    return { from: now - ms, to: now };
   }
 
   // Default: last 15 minutes


### PR DESCRIPTION
## Summary

- 修复 `resolveTimeRange` 中 `--from`/`--to` 被 `--last` 默认值覆盖的 bug
- 影响 `alerts search`、`issues search`、`trace search` 等 11 个命令
- 当用户显式传入 `--from`/`--to` 时，现在会正确优先使用，不再被 `--last` 的默认值拦截

## Root Cause

commander 的 `.option('-l, --last <duration>', 'Time range', '1h')` 会给 `opts.last` 设默认值 `'1h'`，而 `resolveTimeRange` 先判断 `opts.last`，导致 `--from`/`--to` 永远不会生效。

## Fix

调换 `resolveTimeRange` 中的判断顺序：`opts.from` 优先于 `opts.last`。

## Test plan

- [x] 新增单测覆盖 `--from/--to` 与 `--last` 同时存在的优先级场景
- [x] `pnpm typecheck && pnpm lint && pnpm test` 全部通过（41 tests passed）