### PR TITLE
ci: 切换 npm 发布到 Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Upgrade npm for Trusted Publishing
+        run: |
+          npm install -g npm@^11
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -55,8 +60,6 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
   beta-release:
     name: Beta Release
@@ -80,6 +83,11 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
+
+      - name: Upgrade npm for Trusted Publishing
+        run: |
+          npm install -g npm@^11
+          npm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -136,9 +144,6 @@ jobs:
       - name: Publish beta to npm
         if: steps.check-pre.outputs.is_pre == 'true' && steps.check-version.outputs.has_changes == 'true'
         run: pnpm changeset publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Commit version bump back to branch
         if: steps.check-pre.outputs.is_pre == 'true' && steps.check-version.outputs.has_changes == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,5 +112,5 @@ pnpm changeset
 |------|------|------|
 | "No changesets found" | 忘了加 changeset | `pnpm changeset` 后提交新文件 |
 | `octo --version` 输出老版本号 | dist 没重新构建 | `pnpm build` |
-| CI publish 失败 | `NPM_TOKEN` secret 未配或过期 | 仓库 Settings → Secrets → Actions |
+| CI publish 失败 | npm Trusted Publisher 未配或 workflow 文件名不匹配 | npmjs.com 包页面 → Settings → Trusted Publisher 检查 GitHub repo 与 workflow 文件名（`publish.yml`） |
 | `pnpm install --frozen-lockfile` 失败 | 依赖变更没同步 lockfile | 本地 `pnpm install` 后提交 `pnpm-lock.yaml` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,9 +205,9 @@ chore: bump dependencies
 
 lockfile 漂移了。本地 `pnpm install`，把 `pnpm-lock.yaml` 一起提交。
 
-### 发版 workflow 报 `NPM_TOKEN` 错误
+### 发版 workflow 报 npm 鉴权错误
 
-Maintainer 需要在仓库 Settings → Secrets → Actions 配 npm automation token。贡献者不用关心。
+本仓库走 npm Trusted Publishing（OIDC），不再依赖静态 token。Maintainer 需要在 npmjs.com 包页面 Settings → Trusted Publisher 里把 GitHub repo + workflow 文件名（`publish.yml`）配上。贡献者不用关心。
 
 ### 本地预览一下发版效果
 


### PR DESCRIPTION
## Summary

- 把 npm 发布从静态 `NPM_TOKEN` 切换到 npm Trusted Publishing（OIDC），删除 `NODE_AUTH_TOKEN` / `NPM_CONFIG_PROVENANCE` env
- 在 release / beta-release 两个 job 升级 npm 到 `^11`（Trusted Publishing 要求 >= 11.5.1，Node 22 自带 npm 10.x 不够），并打印 `npm --version` 方便排障
- 同步更新 CLAUDE.md / CONTRIBUTING.md 中关于发版鉴权失败的排错指引

## Prerequisites（已完成）

- [x] npmjs.com 包页面 Settings → Trusted Publisher 已配置
  - Publisher: GitHub Actions
  - Org: `kanyun-inc`
  - Repo: `octo-cli`
  - Workflow filename: `publish.yml`
  - Environment: 留空

## Test plan

- [ ] 合入后等下一次有 changeset 的 PR 触发 Release workflow
- [ ] 观察日志中 `npm --version` 输出 11.x.x
- [ ] 确认 `pnpm release` / `changeset publish` 调用成功且 npm 端有 provenance 标记
- [ ] 第一次 OIDC 发版成功后，从 repo Secrets 中移除 `NPM_TOKEN`（保留 fallback 直到验证通过）

## Notes

- 不需要 changeset：纯 CI 配置改动，对外行为无变化
- 已通过 sparring (Cursor Agent) 二轮 review APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)