### PR TITLE
chore: 验证 npm Trusted Publishing 发布链路 (0.7.3 → 0.7.4)

### DIFF
--- a/.changeset/verify-trusted-publishing.md
+++ b/.changeset/verify-trusted-publishing.md
@@ -1,0 +1,7 @@
+---
+'octo-cli': patch
+---
+
+验证 npm Trusted Publishing (OIDC) 发布链路。
+
+- 无功能变更，仅触发一次 patch 发版以确认 GitHub Actions 通过 OIDC 成功发布到 npm 且带 provenance


### PR DESCRIPTION
## Summary

- 仅新增一个 patch changeset，用于触发一次真实发版来验证刚切换到的 npm Trusted Publishing (OIDC) 链路
- 无任何代码/功能改动

## 合并后的预期流程

1. 本 PR 合入 `main`
2. Release workflow 自动开 "chore: version packages" PR（patch bump 0.7.3 → 0.7.4）
3. 合并 Version Packages PR → 触发 npm publish via OIDC
4. 验证点：
   - [ ] Release workflow 日志中 `npm --version` 输出 11.x.x
   - [ ] `pnpm release` 成功（无 NPM_TOKEN env）
   - [ ] npmjs.com 上新版本 0.7.4 显示 provenance 标记
5. 验证通过后从 repo Secrets 中删除 `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)