### PR TITLE
feat: OctoClient 请求带 User-Agent 头 + 验证 Trusted Publishing

### DIFF
--- a/.changeset/client-user-agent.md
+++ b/.changeset/client-user-agent.md
@@ -1,0 +1,5 @@
+---
+'octo-cli': patch
+---
+
+OctoClient 所有请求带上 `User-Agent: octo-cli/<version> (node <ver>; <platform>)`，方便在网关日志里统计 CLI 调用量与版本分布。

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -3,12 +3,18 @@ import { OctoClient } from './client.js';
 
 // Intercept fetch to capture request details
 function captureFetch() {
-  const calls: { url: string; method: string; body: string }[] = [];
+  const calls: {
+    url: string;
+    method: string;
+    body: string;
+    headers: Record<string, string>;
+  }[] = [];
   const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
     calls.push({
       url,
       method: init.method ?? 'GET',
       body: (init.body as string) ?? '',
+      headers: (init.headers as Record<string, string>) ?? {},
     });
     return new Response(JSON.stringify({ code: 0, data: null, message: 'ok' }));
   });
@@ -75,6 +81,17 @@ describe('OctoClient alert methods', () => {
     const body = JSON.parse(calls[0].body);
     expect(Array.isArray(body)).toBe(true);
     expect(body[0].name).toBe('test-rule');
+    vi.restoreAllMocks();
+  });
+
+  it('every request carries an octo-cli User-Agent', async () => {
+    const calls = captureFetch();
+    await client.alertRulesDelete(1);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].headers['User-Agent']).toMatch(
+      /^octo-cli\/[^ ]+ \(node v\d+\.\d+\.\d+; [a-z0-9]+\)$/
+    );
     vi.restoreAllMocks();
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,11 @@
 import { generateAuthorizationHeader } from './auth.js';
 
+declare const __PKG_VERSION__: string;
+
+const PKG_VERSION =
+  typeof __PKG_VERSION__ === 'string' ? __PKG_VERSION__ : 'dev';
+const USER_AGENT = `octo-cli/${PKG_VERSION} (node ${process.version}; ${process.platform})`;
+
 interface ApiResponse<T = unknown> {
   code: number;
   data: T;
@@ -48,6 +54,7 @@ export class OctoClient {
       headers: {
         'Content-Type': 'application/json',
         Authorization: authorization,
+        'User-Agent': USER_AGENT,
       },
       body: payload || undefined,
     });


### PR DESCRIPTION
## Summary

- OctoClient 所有请求自动带 `User-Agent: octo-cli/<version> (node <ver>; <platform>)`，方便在网关 access log 按 UA 统计 CLI 调用量、版本与平台分布
- 顺带捎上 `chore/verify-trusted-publishing` 那次的 changeset，本次合并即完成 npm OIDC 发布链路验证

## Why

octo-cli 没埋遥测，之前没法回答"一共调过多少次"。原生 fetch 默认 UA 就是 `node`，混在其它客户端里看不出来。加一个明确的 UA 后，自监控环境（octopus-self）网关日志就能精确数 CLI 流量。

## Changes

- `src/client.ts`: 在 `request()` 加 `User-Agent` 头，版本号通过 tsup `__PKG_VERSION__` 注入，运行时 typeof 兜底为 `dev`
- `src/client.test.ts`: 捕获 fetch headers，新增格式断言
- `.changeset/client-user-agent.md`: patch

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm test` 22 passed（包含新增 UA 断言）
- [x] `pnpm build` 通过，dist 中 UA 字符串正确注入 `octo-cli/0.7.3`
- [x] Sparring (Cursor Agent) review APPROVE
- [ ] 合并 + 发版后，在 self 环境调一次 CLI，确认 nginx access log 能按 `User-Agent ~ "octo-cli/"` 命中

🤖 Generated with [Claude Code](https://claude.com/claude-code)