### PR TITLE
feat: 新增告警详情和告警时序数据查询接口

### DIFF
--- a/.changeset/add-alert-detail-timeseries.md
+++ b/.changeset/add-alert-detail-timeseries.md
@@ -1,0 +1,9 @@
+---
+'octo-cli': minor
+---
+
+新增告警详情和告警时序数据查询命令
+
+- `alerts detail <alertId>`: 获取告警详情（规则条件、触发维度、状态等）
+- `alerts timeseries <alertId>`: 获取告警检测时序数据（时间点、值、标签、条件状态）
+- MCP 工具: `octo_alerts_detail`、`octo_alerts_timeseries`

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -219,6 +219,14 @@ npx octo-cli alerts search -s firing -l 1h                    # firing alerts
 npx octo-cli alerts search -s firing -p P0,P1 -l 6h           # P0/P1 only
 npx octo-cli alerts search --service myapp -s all -l 1d        # by service
 
+# Alert detail
+npx octo-cli alerts detail 12345                               # get alert detail
+
+# Alert timeseries (detection data)
+npx octo-cli alerts timeseries 12345 -l 1h                     # last 1h
+npx octo-cli alerts timeseries 12345 --from "2026-01-01T00:00:00" --to "2026-01-01T12:00:00"
+npx octo-cli alerts timeseries 12345 --condition-id 0 -l 2h    # specific condition
+
 # Alert rules
 npx octo-cli alerts rules --group-id -1                        # all rules
 npx octo-cli alerts rules --search "error" --page 1 --page-size 10

--- a/skills/octopus-openapi/SKILL.md
+++ b/skills/octopus-openapi/SKILL.md
@@ -478,6 +478,20 @@ Body 为规则 **数组**；字段含 `name`、`env`、`priority`、`ruleType`�
 
 ### 7.6 删除静默 `DELETE /infra-octopus-openapi/v1/alerts/silences/{ruleId}`
 
+### 7.7 告警详情 `GET /infra-octopus-openapi/v1/alerts/{id}`
+
+返回告警基本信息、规则条件（含查询表达式和阈值）及触发维度组合。
+
+响应字段：`id`、`title`、`priority`、`status`、`env`、`scope`、`alertRuleType`、`activeTime`、`duration`、`tags`、`description`、`rule`（含 `id`、`name`、`conditionEvaluationType`、`conditions`）、`activeMergedGroup`。
+
+### 7.8 告警检测时序数据 `GET /infra-octopus-openapi/v1/alerts/{id}/timeseries`
+
+返回告警对应的检测时序数据（时间点、值、标签、条件状态），供分析告警触发趋势使用。
+
+Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`conditionId`（可选，默认 0）。
+
+响应字段：`labelList`（标签列表）、`times`（时间序列）、`values`（多条线的值）、`currentStatus`（当前条件状态）。
+
 ---
 
 ## 八、服务查询相关接口

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -95,6 +95,50 @@ describe('OctoClient alert methods', () => {
     vi.restoreAllMocks();
   });
 
+  it('alertDetail uses GET with path parameter', async () => {
+    const calls = captureFetch();
+    await client.alertDetail(99);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/alerts/99'
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('alertTimeseries uses GET with query parameters', async () => {
+    const calls = captureFetch();
+    await client.alertTimeseries({
+      alertId: 42,
+      from: 1000,
+      to: 2000,
+      conditionId: 3,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/alerts/42/timeseries?from=1000&to=2000&conditionId=3'
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('alertTimeseries omits conditionId when not provided', async () => {
+    const calls = captureFetch();
+    await client.alertTimeseries({
+      alertId: 42,
+      from: 1000,
+      to: 2000,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/alerts/42/timeseries?from=1000&to=2000'
+    );
+    vi.restoreAllMocks();
+  });
+
   it('alertSilenceCreate sends correct structure', async () => {
     const calls = captureFetch();
     await client.alertSilenceCreate({

--- a/src/client.ts
+++ b/src/client.ts
@@ -173,6 +173,28 @@ export class OctoClient {
     );
   }
 
+  async alertDetail(alertId: number) {
+    return this.get(`/infra-octopus-openapi/v1/alerts/${alertId}`);
+  }
+
+  async alertTimeseries(params: {
+    alertId: number;
+    from: number;
+    to: number;
+    conditionId?: number;
+  }) {
+    const qs = new URLSearchParams({
+      from: String(params.from),
+      to: String(params.to),
+    });
+    if (params.conditionId != null) {
+      qs.set('conditionId', String(params.conditionId));
+    }
+    return this.get(
+      `/infra-octopus-openapi/v1/alerts/${params.alertId}/timeseries?${qs}`
+    );
+  }
+
   async alertSilenceDelete(ruleId: number) {
     return this.del(`/infra-octopus-openapi/v1/alerts/silences/${ruleId}`);
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -284,6 +284,40 @@ export function registerCommands(program: Command): void {
     });
 
   alerts
+    .command('detail')
+    .description('Get alert detail')
+    .argument('<alertId>', 'Alert ID')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (alertId, opts) => {
+      const client = getClient();
+      const data = await client.alertDetail(Number.parseInt(alertId, 10));
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  alerts
+    .command('timeseries')
+    .description('Get alert detection timeseries data')
+    .argument('<alertId>', 'Alert ID')
+    .option('--condition-id <id>', 'Condition ID (default 0)')
+    .option('-l, --last <duration>', 'Time range', '1h')
+    .option('--from <time>', 'Start time')
+    .option('--to <time>', 'End time')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (alertId, opts) => {
+      const client = getClient();
+      const { from, to } = resolveTimeRange(opts);
+      const data = await client.alertTimeseries({
+        alertId: Number.parseInt(alertId, 10),
+        from,
+        to,
+        conditionId: opts.conditionId
+          ? Number.parseInt(opts.conditionId, 10)
+          : undefined,
+      });
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  alerts
     .command('unsilence')
     .description('Delete alert silence')
     .argument('<ruleId>', 'Alert rule ID')

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -256,6 +256,42 @@ export async function startMcpServer(): Promise<void> {
         },
       },
       {
+        name: 'octo_alerts_detail',
+        description:
+          'Get Octopus alert detail including rule conditions, trigger dimensions, and status.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            alertId: {
+              type: 'number',
+              description: 'Alert ID',
+            },
+          },
+          required: ['alertId'],
+        },
+      },
+      {
+        name: 'octo_alerts_timeseries',
+        description:
+          'Get Octopus alert detection timeseries data (time points, values, labels, condition status).',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            alertId: {
+              type: 'number',
+              description: 'Alert ID',
+            },
+            from: fromProp,
+            to: toProp,
+            conditionId: {
+              type: 'number',
+              description: 'Condition ID (default 0 for first condition)',
+            },
+          },
+          required: ['alertId'],
+        },
+      },
+      {
         name: 'octo_alerts_silence_create',
         description:
           'Create an alert silence (mute) in Octopus. Suppresses notifications for a rule during a time window.',
@@ -555,6 +591,22 @@ export async function startMcpServer(): Promise<void> {
           const ruleId = args.ruleId as number;
           await client.alertRulesDelete(ruleId);
           return ok(`Alert rule ${ruleId} deleted`);
+        }
+
+        case 'octo_alerts_detail': {
+          const data = await client.alertDetail(args.alertId as number);
+          return ok(JSON.stringify(data, null, 2));
+        }
+
+        case 'octo_alerts_timeseries': {
+          const { from, to } = timeDefaults(args);
+          const data = await client.alertTimeseries({
+            alertId: args.alertId as number,
+            from,
+            to,
+            conditionId: args.conditionId as number | undefined,
+          });
+          return ok(JSON.stringify(data, null, 2));
         }
 
         case 'octo_alerts_silence_create': {


### PR DESCRIPTION
## Summary

- 新增 `alerts detail <alertId>` 命令，获取告警详情（规则条件、触发维度、状态等）
- 新增 `alerts timeseries <alertId>` 命令，获取告警检测时序数据（时间点、值、标签、条件状态）
- 同步注册 MCP tools: `octo_alerts_detail`、`octo_alerts_timeseries`

对应后端 MR: https://gitlab-ee.zhenguanyu.com/yuanli/infra-octopus/-/merge_requests/4348

## Changes

| 文件 | 变更 |
|------|------|
| `src/client.ts` | 添加 `alertDetail()` 和 `alertTimeseries()` 方法 |
| `src/commands.ts` | 注册 `alerts detail` 和 `alerts timeseries` 子命令 |
| `src/mcp.ts` | 注册 MCP tools 定义和 handler |
| `src/client.test.ts` | 新增 3 个测试用例 |
| `skills/SKILL.md` | 补充命令示例 |
| `skills/octopus-openapi/SKILL.md` | 补充接口文档 (7.7, 7.8) |

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm test` 通过 (45 tests)
- [x] `pnpm build` 通过