### PR TITLE
fix: octo users 命令报「用户名称列表不能为空」

### DIFF
--- a/.changeset/fix-users-field-name.md
+++ b/.changeset/fix-users-field-name.md
@@ -1,0 +1,8 @@
+---
+'octo-cli': patch
+---
+
+修复 `octo users` 命令报错「用户名称列表不能为空」的问题。
+
+- `usersSearch` 请求体字段名从 `name` 改为 `names`，与后端 API 实际期望一致
+- 同步修正 SKILL.md 中的错误示例（`"name"` → `"names"`）

--- a/skills/octopus-openapi/SKILL.md
+++ b/skills/octopus-openapi/SKILL.md
@@ -528,7 +528,7 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ### 用户列表 `POST /infra-octopus-openapi/v1/users/search`
 
-请求体示例：`{ "name": [] }`（用户名称列表）。响应含用户 `id`、`name` 等。
+请求体示例：`{ "names": [] }`（用户名称列表）。响应含用户 `id`、`name` 等。
 
 ---
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -139,6 +139,21 @@ describe('OctoClient alert methods', () => {
     vi.restoreAllMocks();
   });
 
+  it('usersSearch sends names (plural) as field key', async () => {
+    const calls = captureFetch();
+    await client.usersSearch(['alice', 'bob']);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/users/search'
+    );
+    const body = JSON.parse(calls[0].body);
+    expect(body.names).toEqual(['alice', 'bob']);
+    expect(body.name).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
   it('alertSilenceCreate sends correct structure', async () => {
     const calls = captureFetch();
     await client.alertSilenceCreate({

--- a/src/client.ts
+++ b/src/client.ts
@@ -429,7 +429,7 @@ export class OctoClient {
 
   async usersSearch(names: string[]) {
     return this.post('/infra-octopus-openapi/v1/users/search', {
-      name: names,
+      names,
     });
   }
 }


### PR DESCRIPTION
## 问题

`octo users <name>` 报 400：`{"code":-14,"message":"用户名称列表不能为空"}`

## 根因

`client.ts` 发送的请求体字段名是 `name`（单数），但后端 API 读取的是 `names`（复数）。后端收到 `name` 字段、`names` 为 undefined，判定为空列表报错。

直接 curl 验证：
- `{ name: ["liangfeng"] }` → 400 "用户名称列表不能为空"  
- `{ names: ["liangfeng"] }` → 200 成功

## 修复

- `src/client.ts`: `name: names` → `names`
- `skills/octopus-openapi/SKILL.md`: 更正示例中的字段名
- `src/client.test.ts`: 新增测试断言字段名正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)