### PR TITLE
refactor: 优化 mcp 查询 prompt

### DIFF
--- a/.changeset/improve-mcp-query-guidance.md
+++ b/.changeset/improve-mcp-query-guidance.md
@@ -1,0 +1,9 @@
+---
+'octo-cli': patch
+---
+
+增强 MCP 工具的查询语法提示，避免 Agent 生成错误的 Octopus 查询条件。
+
+- 在 MCP `query` 参数描述中补充 Octopus 搜索语法，明确使用 `field = value` 而不是 `field:value`
+- 补充常用比较运算、逻辑运算、大小写规则、通配符规则和常用字段说明
+- 补充 `from` / `to` 时间参数说明，明确默认时间范围和最近 1 小时查询的传参方式

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -49,15 +49,18 @@ const envProp = {
 };
 const fromProp = {
   type: 'number',
-  description: 'Start time in epoch ms',
+  description:
+    'Start time in epoch milliseconds. If omitted, the tool defaults to the last 15 minutes; for "last 1h", pass now-3600000.',
 };
 const toProp = {
   type: 'number',
-  description: 'End time in epoch ms',
+  description:
+    'End time in epoch milliseconds. If omitted, defaults to now.',
 };
 const queryProp = {
   type: 'string',
-  description: 'Query string (Octopus query syntax)',
+  description:
+    'Octopus search syntax, not Lucene/Elasticsearch. Field filters use `field = value`, `!=`, `>`, `>=`, `<`, `<=`, `in (...)`, `not in (...)`; do not use `field:value`. Values and field names are case-sensitive, operators AND/OR/NOT are case-insensitive. Use parentheses for grouping and double quotes for exact phrases. Wildcards only work in field search, e.g. `service = web*`. Common fields: service, level (FATAL/ERROR/WARN/INFO/DEBUG/TRACE), host, trace_id, issue_id, k8s.pod.name, source. Examples: `level = ERROR`, `service = octopus-query-proxy`, `service = myapp AND level = ERROR`, `(level = ERROR OR level = WARN) AND service = myapp`.',
 };
 
 function timeDefaults(args: Record<string, unknown>): {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -54,8 +54,7 @@ const fromProp = {
 };
 const toProp = {
   type: 'number',
-  description:
-    'End time in epoch milliseconds. If omitted, defaults to now.',
+  description: 'End time in epoch milliseconds. If omitted, defaults to now.',
 };
 const queryProp = {
   type: 'string',


### PR DESCRIPTION
## 改动说明

<!-- 简要描述这次 PR 干了什么、为什么 -->
具体包括：
明确字段查询要用 field = value，不要用 field:value
补充常用比较运算、in / not in、AND / OR / NOT、括号分组、精确短语、通配符规则
列出常用字段和 level 可选值
补充 from/to 的 epoch ms 说明，以及默认时间范围是最近 15 分钟
为什么做：
直接 npm 安装使用 MCP 时，Agent 只能看到 MCP tools schema，看不到本地 skill 文档，容易把“查询最近 1h 的错误日志”写成 level:error。把关键查询规则放进 MCP schema 后，Agent 只依赖 MCP metadata 也更容易生成正确的 level = ERROR 查询。
## Checklist

- [ ] 代码已通过 `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- [ ] 已补齐必要的测试
- [ ] 已运行 `pnpm changeset` 并提交 `.changeset/*.md`（纯文档/重构/测试可跳过）
- [ ] README / CONTRIBUTING 相关文档已同步（如有必要）
