### PR TITLE
feat: support case/对齐mcp和cli

### DIFF
--- a/.changeset/gentle-cases-appear.md
+++ b/.changeset/gentle-cases-appear.md
@@ -1,0 +1,5 @@
+---
+"octo-cli": minor
+---
+
+Add OpenAPI Case support across CLI, MCP tools, client wrappers, docs, and tests.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $ # 根因：resume 机制 + onFinish 回调 + 状态刷新形成无限循环
 ## 功能特性
 
 - **Agent 原生接入** —— `login` 全局装 Skill，`init` 生成项目上下文，Agent 自己填写
-- **全量 Octopus OpenAPI 覆盖** —— 日志、告警、Issue、链路、指标、服务、LLM、RUM、事件、大盘
+- **全量 Octopus OpenAPI 覆盖** —— 日志、告警、Issue、Case、链路、指标、服务、LLM、RUM、事件、大盘
 - **人性化时间范围** —— `--last 15m`、`--last 2h`、`--last 7d`
 - **多种输出格式** —— `--output json`、`--output table`、`--output jsonl`
 - **MCP Server** —— 内置 stdio MCP Server，支持 Claude Code、Cursor 等
@@ -221,6 +221,16 @@ octo-cli issues assign --user 123 --ids id1,id2          # 分配 Issue
 octo-cli issues update --ids id1,id2 -s resolved          # 解决 Issue
 ```
 
+### Case
+
+```bash
+octo-cli cases list --status todo --priority P1           # 待处理 Case
+octo-cli cases create --name "线上故障" --group-id 1 --priority P0
+octo-cli cases detail <caseId>                            # Case 详情
+octo-cli cases link <caseId> --type alert --target-id 123 # 关联告警
+octo-cli cases note <caseId> --text "已通知负责人"          # 添加备注
+```
+
 ### 链路 (Trace)
 
 ```bash
@@ -277,6 +287,13 @@ octo-cli users alice bob                                  # 按姓名搜索用�
 | `issues detail` | Issue 详情 |
 | `issues assign` | 批量分配 Issue |
 | `issues update` | 批量更新 Issue 状态 |
+| `cases list` | 查询 Case |
+| `cases create` | 创建 Case |
+| `cases detail` / `cases detail-key` | Case 详情 |
+| `cases update` / `cases delete` | 更新或删除 Case |
+| `cases link` / `cases unlink` | 关联或取消关联告警/Issue |
+| `cases note` / `cases note-update` | 添加或修改 Case 备注 |
+| `cases groups` / `cases group-create` | 查询或创建 Case 分组 |
 | `trace search` | 搜索链路 Span |
 | `trace aggregate` | 链路聚合 |
 | `metrics query` | 指标时序查询 |
@@ -373,13 +390,28 @@ npx octo-cli mcp-install
 | `octo_alerts_silence_create` | 创建告警静默 |
 | `octo_alerts_silence_delete` | 解除告警静默 |
 | `octo_issues_search` | 搜索错误追踪 Issue |
+| `octo_issues_detail` | Issue 详情 |
+| `octo_issues_assign` | 批量分配 Issue |
+| `octo_issues_update` | 批量更新 Issue 状态 |
+| `octo_cases_list` | 查询 Case |
+| `octo_cases_create` | 创建 Case |
+| `octo_cases_detail` / `octo_cases_detail_by_key` | Case 详情 |
+| `octo_cases_update` / `octo_cases_delete` | 更新或删除 Case |
+| `octo_cases_link` / `octo_cases_unlink` | 关联或取消关联告警/Issue |
+| `octo_cases_note_add` / `octo_cases_note_update` | 添加或修改 Case 备注 |
+| `octo_cases_groups_all` / `octo_cases_group_create` | 查询或创建 Case 分组 |
 | `octo_trace_search` | 搜索链路 Span |
+| `octo_trace_aggregate` | 链路聚合 |
 | `octo_metrics_query` | 指标时序查询 |
+| `octo_metrics_point` | 指标单点查询 |
 | `octo_services_list` | 服务列表 |
+| `octo_services_entries` | 服务入口列表 |
 | `octo_services_topology` | 服务拓扑图 |
 | `octo_llm_list` | LLM Span 查询 |
 | `octo_rum_list` | RUM 事件查询 |
+| `octo_rum_detail` | RUM 事件详情 |
 | `octo_events_list` | 事件查询 |
+| `octo_users_search` | 用户搜索 |
 
 ## 配套 Skill
 
@@ -408,13 +440,14 @@ octo-cli 封装了 [Octopus OpenAPI](https://www.notion.so/OpenAPI-1b42090d16b68
 | 日志 | `/v1/logs/search`、`/v1/logs/aggregate` |
 | 告警 | `/v1/alerts/search`、`/v1/alert/rules/search`、`/v1/alert/rules`、`/v1/alerts/silences/*` |
 | Issue | `/v1/log-error-tracking/issues/*` |
+| Case | `/v1/cases/*`、`/v1/cases/groups/*` |
 | 链路 | `/v1/trace/span/list`、`/v1/trace/aggregate` |
 | 指标 | `/v1/metrics/query/timeseries`、`/v1/metrics/query/queryMetric` |
 | 服务 | `/v1/apm/query/*`、`/v1/apm/topology/*` |
 | LLM | `/v1/llm/span/list` |
 | RUM | `/v1/rum/list`、`/v1/rum/{id}`、`/v1/rum/aggregate` |
 | 事件 | `/v1/event/list` |
-| 大盘 | `/v1/dashboards`（CRUD） |
+| 大盘 | `/v1/dashboards`（创建 / 更新） |
 | 用户 | `/v1/users/search` |
 
 鉴权：支持 Personal Access Token（Bearer Token）和 Application Key（OC-HMAC-SHA256-2 签名）。默认地址：`https://octopus-app.zhenguanyu.com`。

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octo
-description: Query Octopus observability platform — logs, alerts, traces, metrics, issues, services, LLM, RUM, events. Triggers on "logs", "alerts", "traces", "metrics", "octopus", "observability", "error tracking", "RUM", "LLM observability"
+description: Query Octopus observability platform — logs, alerts, traces, metrics, issues, cases, services, LLM, RUM, events. Triggers on "logs", "alerts", "traces", "metrics", "octopus", "observability", "error tracking", "cases", "RUM", "LLM observability"
 version: 0.2.0
 author: kris
 tags:
@@ -10,14 +10,15 @@ tags:
   - alerts
   - traces
   - metrics
+  - cases
 user-invocable: true
-argument-hint: "logs search -q 'level = ERROR' | alerts search -s firing | trace search"
+argument-hint: "logs search -q 'level = ERROR' | alerts search -s firing | cases list | trace search"
 allowed-tools: Bash(*)
 ---
 
 # Octopus CLI — Query Observability Data
 
-CLI tool `octo-cli` for querying the Octopus observability platform (octopus.zhenguanyu.com). Covers logs, alerts, error tracking, traces, metrics, services, LLM, RUM, and events.
+CLI tool `octo-cli` for querying the Octopus observability platform (octopus.zhenguanyu.com). Covers logs, alerts, error tracking, cases, traces, metrics, services, LLM, RUM, and events.
 
 ## Onboarding (first time in a project)
 
@@ -76,6 +77,9 @@ npx octo-cli rum list -q "application.name = <SERVICE>" -e online -l 1d -n 1
 
 # Check existing issues
 npx octo-cli issues search -q "service = <SERVICE>" --status unresolved -l 7d
+
+# Check open cases
+npx octo-cli cases list --status todo --input "<SERVICE>"
 ```
 
 **3c. Write findings into the template**, replacing all `<!-- AGENT: -->` sections.
@@ -249,6 +253,25 @@ npx octo-cli issues detail <issueId>
 # Manage
 npx octo-cli issues assign --user 123 --ids id1,id2
 npx octo-cli issues update --ids id1,id2 -s resolved
+```
+
+### Cases
+
+```bash
+# List cases
+npx octo-cli cases list --status todo --priority P1
+npx octo-cli cases list --group-id 1 --input "checkout" --page 1 --page-size 20
+
+# Create and inspect
+npx octo-cli cases create --name "checkout incident" --group-id 1 --priority P0
+npx octo-cli cases detail <caseId>
+npx octo-cli cases detail-key <caseKey>
+
+# Manage relations and notes
+npx octo-cli cases link <caseId> --type alert --target-id 12345
+npx octo-cli cases link <caseId> --type issue --target-id <issueId>
+npx octo-cli cases note <caseId> --text "owner notified"
+npx octo-cli cases groups
 ```
 
 ### Traces

--- a/skills/octopus-openapi/SKILL.md
+++ b/skills/octopus-openapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octopus-openapi
-description: Octopus OpenAPI 接口指南。涵盖 ApplicationKey 与 V1/V2（OC-HMAC-SHA256 / OC-HMAC-SHA256-2）鉴权、Python/Java SDK、日志/Trace/指标（含 V2.0）/错误追踪/告警/服务 APM/大盘/用户/LLM/RUM/事件等 HTTP 接口与限流说明。用于对接 Octopus 可观测数据开放 API。
+description: Octopus OpenAPI 接口指南。涵盖 ApplicationKey 与 V1/V2（OC-HMAC-SHA256 / OC-HMAC-SHA256-2）鉴权、Python/Java SDK、日志/Trace/指标（含 V2.0）/错误追踪/Case/告警/服务 APM/大盘/用户/LLM/RUM/事件等 HTTP 接口与限流说明。用于对接 Octopus 可观测数据开放 API。
 version: 1.1.0
 tags:
   - octopus
@@ -25,13 +25,14 @@ tags:
 | [Trace](#四trace-查询相关接口) | span list / aggregate |
 | [指标](#五指标查询相关接口) | timeseries / queryMetric，及 [V2.0](#指标接口-v20) |
 | [错误追踪](#六错误追踪相关接口) | Issue 查询、详情、分布、分配、状态与 `ignoreRule` |
-| [告警](#七告警查询相关接口) | 告警查询、规则 CRUD、静默 |
-| [服务 APM](#八服务查询相关接口) | 入口/上下游/拓扑/时序等 |
-| [大盘](#九大盘相关接口) | 创建 / 更新 / 删除大盘 |
-| [用户](#十用户查询相关接口) | 用户列表 |
-| [LLM](#十一llm-查询相关接口) | LLM span 列表 |
-| [RUM](#十二rum-查询相关接口) | 列表 / 详情 / 聚合 |
-| [事件](#十三事件查询相关接口) | Event 列表 |
+| [Case](#七case-相关接口) | Case 列表、详情、创建更新、关系、备注、分组 |
+| [告警](#八告警查询相关接口) | 告警查询、规则 CRUD、静默 |
+| [服务 APM](#九服务查询相关接口) | 入口/上下游/拓扑/时序等 |
+| [大盘](#十大盘相关接口) | 创建 / 更新大盘 |
+| [用户](#十一用户查询相关接口) | 用户列表 |
+| [LLM](#十二llm-查询相关接口) | LLM span 列表 |
+| [RUM](#十三rum-查询相关接口) | 列表 / 详情 / 聚合 |
+| [事件](#十四事件查询相关接口) | Event 列表 |
 
 **API 根路径约定**：下文接口路径均以 `https://<host>/infra-octopus-openapi/v1` 为前缀。常见 host 为 `octopus-app.zhenguanyu.com`（与官方 SDK 示例一致）；部分文档链接使用 `octopus.zhenguanyu.com`，部署环境以前者为准或按运维说明切换。
 
@@ -452,39 +453,79 @@ public class OctopusOpenapiClient {
 
 ---
 
-## 七、告警查询相关接口
+## 七、Case 相关接口
+
+Case 返回结构与 `infra-octopus-rest` 的 Case API 保持一致；OpenAPI 模块内定义同构 DTO，不直接依赖 REST 模块的 Logic/VO。
+
+### 7.1 Case 列表 `POST /infra-octopus-openapi/v1/cases/list`
+
+请求字段：`pageNo`、`pageSize`、`groupId`、`status`（`todo` | `doing` | `done`）、`priority`（`NONE` | `P0` | `P1` | `P2`）、`assignerId`、`input`（按名称匹配）。返回 `PageData<CaseListVO>`。
+
+### 7.2 创建 Case `POST /infra-octopus-openapi/v1/cases`
+
+请求字段：`name`、`groupId`、`priority`、`status`、`assignerId`、`description`。未传 `priority` / `status` 时服务端默认 `NONE` / `todo`。
+
+### 7.3 Case 详情
+
+- 按 ID：`POST /infra-octopus-openapi/v1/cases/{id}`
+- 按 CaseKey：`POST /infra-octopus-openapi/v1/cases/key/{caseKey}`
+
+详情包含 `relationList` 与 `timelineList`。关联对象字段语义：Alert 关系使用 `relationList[].alert`，Issue 关系使用 `relationList[].issue`。
+
+### 7.4 更新 / 删除 Case
+
+- 更新：`PUT /infra-octopus-openapi/v1/cases/{id}`，请求字段为 `groupId`、`priority`、`status`、`assignerId`、`description`
+- 删除：`DELETE /infra-octopus-openapi/v1/cases/{id}`
+
+### 7.5 Case 关系与备注
+
+- 关联告警或 Issue：`POST /infra-octopus-openapi/v1/cases/{id}/relation`，请求示例 `{"type":"alert","targetId":"12345"}` 或 `{"type":"issue","targetId":"issue-id"}`
+- 取消关联：`DELETE /infra-octopus-openapi/v1/cases/{id}/relation/{relationId}`
+- 添加备注：`POST /infra-octopus-openapi/v1/cases/{id}/note`，请求体为备注字符串
+- 修改备注：`PUT /infra-octopus-openapi/v1/cases/{id}/note/{noteId}`，请求体为备注字符串
+
+### 7.6 Case 分组
+
+- 全部分组：`GET /infra-octopus-openapi/v1/cases/groups/all`
+- 创建分组：`POST /infra-octopus-openapi/v1/cases/groups`，请求字段 `name`
+
+写操作操作人：ApplicationKey 使用 `userId=0`、`ldap=appId`、`name=applicationKey.name`；Personal Access Token 使用 `userId=pat.userId`、`ldap=Pat:{pat.id}`、`name=pat.name`。
+
+---
+
+## 八、告警查询相关接口
 
 **限流**：单 AppId 每 10 秒 **50** 次（除非另有说明）。
 
-### 7.1 告警查询 `POST /infra-octopus-openapi/v1/alerts/search`
+### 8.1 告警查询 `POST /infra-octopus-openapi/v1/alerts/search`
 
 参数示例：`env`、`from`、`to`、`limit`、`pageNo`、`priorities`（UNKNOWN/P0/P1/P2）、`query`、`status`（all/firing/resolved）、`services`、`alertRuleType`。
 
-### 7.2 告警规则搜索 `POST /infra-octopus-openapi/v1/alert/rules/search`
+### 8.2 告警规则搜索 `POST /infra-octopus-openapi/v1/alert/rules/search`
 
 含 `groupId`、`pageParam`、`statusList`（enabled/disabled/paused/silenced）、`searchInput`、`types`、`tags`、`creator` 等。
 
-### 7.3 创建告警规则 `POST /infra-octopus-openapi/v1/alert/rules`
+### 8.3 创建告警规则 `POST /infra-octopus-openapi/v1/alert/rules`
 
 Body 为规则 **数组**；字段含 `name`、`env`、`priority`、`ruleType`（log/metric/issue）、`conditions`、`conditionEvaluationType`（single/and/or）、`notice`、`groupId`、`tags`、`active` 等（结构复杂，以 Notion 长 JSON 为准）。
 
-### 7.4 删除告警规则 `DELETE /infra-octopus-openapi/v1/alert/rules`
+### 8.4 删除告警规则 `DELETE /infra-octopus-openapi/v1/alert/rules`
 
 请求体含待删 **`ruleId`**（以线上实际为准：亦有文档写作 `ruleIds` 列表，集成时请对照 Swagger）。
 
-### 7.5 告警静默 `POST /infra-octopus-openapi/v1/alerts/silences/create`
+### 8.5 告警静默 `POST /infra-octopus-openapi/v1/alerts/silences/create`
 
 `ruleId`、`alertId`、`startTime`、`endTime`、`scope`（如 ALL / SPECIFY）、`specifyGroups`、`silentlyNotify`。
 
-### 7.6 删除静默 `DELETE /infra-octopus-openapi/v1/alerts/silences/{ruleId}`
+### 8.6 删除静默 `DELETE /infra-octopus-openapi/v1/alerts/silences/{ruleId}`
 
-### 7.7 告警详情 `GET /infra-octopus-openapi/v1/alerts/{id}`
+### 8.7 告警详情 `GET /infra-octopus-openapi/v1/alerts/{id}`
 
 返回告警基本信息、规则条件（含查询表达式和阈值）及触发维度组合。
 
 响应字段：`id`、`title`、`priority`、`status`、`env`、`scope`、`alertRuleType`、`activeTime`、`duration`、`tags`、`description`、`rule`（含 `id`、`name`、`conditionEvaluationType`、`conditions`）、`activeMergedGroup`。
 
-### 7.8 告警检测时序数据 `GET /infra-octopus-openapi/v1/alerts/{id}/timeseries`
+### 8.8 告警检测时序数据 `GET /infra-octopus-openapi/v1/alerts/{id}/timeseries`
 
 返回告警对应的检测时序数据（时间点、值、标签、条件状态），供分析告警触发趋势使用。
 
@@ -494,7 +535,7 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ---
 
-## 八、服务查询相关接口
+## 九、服务查询相关接口
 
 **限流**：单 AppId 每 10 秒 **50** 次。
 
@@ -514,17 +555,16 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ---
 
-## 九、大盘相关接口
+## 十、大盘相关接口
 
 - **创建** `POST /infra-octopus-openapi/v1/dashboards`：Body 含 `parent`（**目录 id，必填**）、`title`、`variableList`、`widgetList` 等；结构复杂，建议从页面已有大盘导出 JSON 再改。可参考浏览器控制台拉取 `infra-octopus-rest` 下大盘详情接口中的 `data` 字段（见 Notion 原文）。
 - **更新** `PUT /infra-octopus-openapi/v1/dashboards/{id}`：**全量覆盖**。
-- **删除** `DELETE /infra-octopus-openapi/v1/dashboards/{id}`：当前仅可删 **同一 APP_ID 创建** 的大盘。
 
 业务与数据结构可能迭代，以最新文档为准。
 
 ---
 
-## 十、用户查询相关接口
+## 十一、用户查询相关接口
 
 ### 用户列表 `POST /infra-octopus-openapi/v1/users/search`
 
@@ -532,7 +572,7 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ---
 
-## 十一、LLM 查询相关接口
+## 十二、LLM 查询相关接口
 
 ### LLM 列表 `POST /infra-octopus-openapi/v1/llm/span/list`
 
@@ -542,7 +582,7 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ---
 
-## 十二、RUM 查询相关接口
+## 十三、RUM 查询相关接口
 
 | 接口 | 方法 | 路径 |
 |------|------|------|
@@ -554,7 +594,7 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ---
 
-## 十三、事件查询相关接口
+## 十四、事件查询相关接口
 
 ### Event 列表 `POST /infra-octopus-openapi/v1/event/list`
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -236,3 +236,214 @@ describe('OctoClient alert methods', () => {
     vi.restoreAllMocks();
   });
 });
+
+describe('OctoClient case methods', () => {
+  const client = new OctoClient('https://example.com', {
+    mode: 'appKey',
+    appId: 'testId',
+    appSecret: 'testSecret',
+  });
+
+  it('casesList posts filter and pagination fields', async () => {
+    const calls = captureFetch();
+    await client.casesList({
+      pageNo: 2,
+      pageSize: 10,
+      groupId: 3,
+      status: 'todo',
+      priority: 'P1',
+      assignerId: 5,
+      input: 'payment',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/list'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      pageNo: 2,
+      pageSize: 10,
+      groupId: 3,
+      status: 'todo',
+      priority: 'P1',
+      assignerId: 5,
+      input: 'payment',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('caseCreate posts a case payload', async () => {
+    const calls = captureFetch();
+    await client.caseCreate({
+      name: 'checkout incident',
+      groupId: 1,
+      priority: 'P0',
+      status: 'doing',
+      assignerId: 2,
+      description: 'investigate checkout failures',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      name: 'checkout incident',
+      groupId: 1,
+      priority: 'P0',
+      status: 'doing',
+      assignerId: 2,
+      description: 'investigate checkout failures',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('caseDetail uses POST with path parameter', async () => {
+    const calls = captureFetch();
+    await client.caseDetail(99);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/99'
+    );
+    expect(calls[0].body).toBe('');
+    vi.restoreAllMocks();
+  });
+
+  it('caseDetailByKey uses POST with case key path parameter', async () => {
+    const calls = captureFetch();
+    await client.caseDetailByKey('CASE-10001');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/key/CASE-10001'
+    );
+    expect(calls[0].body).toBe('');
+    vi.restoreAllMocks();
+  });
+
+  it('caseUpdate uses PUT with editable fields', async () => {
+    const calls = captureFetch();
+    await client.caseUpdate(8, {
+      groupId: 1,
+      priority: 'P2',
+      status: 'done',
+      assignerId: 2,
+      description: 'fixed',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/8'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      groupId: 1,
+      priority: 'P2',
+      status: 'done',
+      assignerId: 2,
+      description: 'fixed',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('caseDelete uses DELETE with path parameter', async () => {
+    const calls = captureFetch();
+    await client.caseDelete(8);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('DELETE');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/8'
+    );
+    expect(calls[0].body).toBe('');
+    vi.restoreAllMocks();
+  });
+
+  it('caseAddRelation posts relation type and target id', async () => {
+    const calls = captureFetch();
+    await client.caseAddRelation(8, {
+      type: 'alert',
+      targetId: '12345',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/8/relation'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      type: 'alert',
+      targetId: '12345',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('caseDeleteRelation uses DELETE with relation path parameter', async () => {
+    const calls = captureFetch();
+    await client.caseDeleteRelation(8, 9);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('DELETE');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/8/relation/9'
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('caseAddNote serializes note text as a JSON string', async () => {
+    const calls = captureFetch();
+    await client.caseAddNote(8, 'first note');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/8/note'
+    );
+    expect(calls[0].body).toBe('"first note"');
+    vi.restoreAllMocks();
+  });
+
+  it('caseUpdateNote serializes note text as a JSON string', async () => {
+    const calls = captureFetch();
+    await client.caseUpdateNote(8, 10, 'updated note');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/8/note/10'
+    );
+    expect(calls[0].body).toBe('"updated note"');
+    vi.restoreAllMocks();
+  });
+
+  it('caseGroupsAll uses GET', async () => {
+    const calls = captureFetch();
+    await client.caseGroupsAll();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/groups/all'
+    );
+    expect(calls[0].body).toBe('');
+    vi.restoreAllMocks();
+  });
+
+  it('caseGroupCreate posts group name', async () => {
+    const calls = captureFetch();
+    await client.caseGroupCreate({ name: 'incident cases' });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/groups'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({ name: 'incident cases' });
+    vi.restoreAllMocks();
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -268,6 +268,91 @@ export class OctoClient {
     );
   }
 
+  // --- Cases ---
+
+  async casesList(params: {
+    pageNo: number;
+    pageSize: number;
+    groupId?: number;
+    status?: string;
+    priority?: string;
+    assignerId?: number;
+    input?: string;
+  }) {
+    return this.post('/infra-octopus-openapi/v1/cases/list', params);
+  }
+
+  async caseCreate(params: {
+    name: string;
+    groupId: number;
+    priority?: string;
+    status?: string;
+    assignerId?: number;
+    description?: string;
+  }) {
+    return this.post('/infra-octopus-openapi/v1/cases', params);
+  }
+
+  async caseDetail(id: number) {
+    return this.post(`/infra-octopus-openapi/v1/cases/${id}`, null);
+  }
+
+  async caseDetailByKey(caseKey: string) {
+    return this.post(`/infra-octopus-openapi/v1/cases/key/${caseKey}`, null);
+  }
+
+  async caseUpdate(
+    id: number,
+    params: {
+      groupId?: number;
+      priority?: string;
+      status?: string;
+      assignerId?: number;
+      description?: string;
+    }
+  ) {
+    return this.put(`/infra-octopus-openapi/v1/cases/${id}`, params);
+  }
+
+  async caseDelete(id: number) {
+    return this.del(`/infra-octopus-openapi/v1/cases/${id}`);
+  }
+
+  async caseAddRelation(
+    id: number,
+    params: {
+      type: string;
+      targetId: string;
+    }
+  ) {
+    return this.post(`/infra-octopus-openapi/v1/cases/${id}/relation`, params);
+  }
+
+  async caseDeleteRelation(id: number, relationId: number) {
+    return this.del(
+      `/infra-octopus-openapi/v1/cases/${id}/relation/${relationId}`
+    );
+  }
+
+  async caseAddNote(id: number, note: string) {
+    return this.post(`/infra-octopus-openapi/v1/cases/${id}/note`, note);
+  }
+
+  async caseUpdateNote(id: number, noteId: number, note: string) {
+    return this.put(
+      `/infra-octopus-openapi/v1/cases/${id}/note/${noteId}`,
+      note
+    );
+  }
+
+  async caseGroupsAll() {
+    return this.get('/infra-octopus-openapi/v1/cases/groups/all');
+  }
+
+  async caseGroupCreate(params: { name: string }) {
+    return this.post('/infra-octopus-openapi/v1/cases/groups', params);
+  }
+
   // --- Trace ---
 
   async traceSpanList(params: {
@@ -441,10 +526,6 @@ export class OctoClient {
 
   async dashboardUpdate(id: number, data: unknown) {
     return this.put(`/infra-octopus-openapi/v1/dashboards/${id}`, data);
-  }
-
-  async dashboardDelete(id: number) {
-    return this.del(`/infra-octopus-openapi/v1/dashboards/${id}`);
   }
 
   // --- Users ---

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,0 +1,58 @@
+import { Command } from 'commander';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerCommands } from './commands.js';
+
+describe('commands', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('cases create --output json writes only machine-readable JSON to stdout', async () => {
+    vi.stubEnv('OCTOPUS_TOKEN', 'test-token');
+    vi.stubEnv('OCTOPUS_BASE_URL', 'https://example.com');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            code: 0,
+            data: { id: 123, name: 'checkout incident' },
+            message: 'ok',
+          })
+        );
+      })
+    );
+
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      logs.push(String(message));
+    });
+
+    const program = new Command();
+    program.exitOverride();
+    registerCommands(program);
+
+    await program.parseAsync(
+      [
+        'node',
+        'octo',
+        'cases',
+        'create',
+        '--name',
+        'checkout incident',
+        '--group-id',
+        '1',
+        '--output',
+        'json',
+      ],
+      { from: 'node' }
+    );
+
+    expect(logs).toHaveLength(1);
+    expect(JSON.parse(logs[0])).toEqual({
+      id: 123,
+      name: 'checkout incident',
+    });
+  });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -456,7 +456,6 @@ export function registerCommands(program: Command): void {
           : undefined,
         description: opts.description,
       });
-      console.log('Case created');
       if (data) printOutput(data, opts.output as OutputFormat);
     });
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -404,6 +404,193 @@ export function registerCommands(program: Command): void {
       console.log('Issues updated');
     });
 
+  // ─── cases ───────────────────────────────────────────────
+  const cases = program.command('cases').description('Case operations');
+
+  cases
+    .command('list')
+    .description('List cases')
+    .option('--group-id <id>', 'Case group ID')
+    .option('-s, --status <status>', 'todo, doing, or done')
+    .option('-p, --priority <priority>', 'NONE, P0, P1, or P2')
+    .option('--assigner-id <id>', 'Assignee user ID')
+    .option('--input <text>', 'Search by case name')
+    .option('--page <n>', 'Page number', '1')
+    .option('--page-size <n>', 'Page size', '20')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (opts) => {
+      const client = getClient();
+      const data = await client.casesList({
+        pageNo: Number.parseInt(opts.page, 10),
+        pageSize: Number.parseInt(opts.pageSize, 10),
+        groupId: opts.groupId ? Number.parseInt(opts.groupId, 10) : undefined,
+        status: opts.status,
+        priority: opts.priority,
+        assignerId: opts.assignerId
+          ? Number.parseInt(opts.assignerId, 10)
+          : undefined,
+        input: opts.input,
+      });
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  cases
+    .command('create')
+    .description('Create a case')
+    .requiredOption('--name <name>', 'Case name')
+    .requiredOption('--group-id <id>', 'Case group ID')
+    .option('-p, --priority <priority>', 'NONE, P0, P1, or P2')
+    .option('-s, --status <status>', 'todo, doing, or done')
+    .option('--assigner-id <id>', 'Assignee user ID')
+    .option('--description <text>', 'Case description')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (opts) => {
+      const client = getClient();
+      const data = await client.caseCreate({
+        name: opts.name,
+        groupId: Number.parseInt(opts.groupId, 10),
+        priority: opts.priority,
+        status: opts.status,
+        assignerId: opts.assignerId
+          ? Number.parseInt(opts.assignerId, 10)
+          : undefined,
+        description: opts.description,
+      });
+      console.log('Case created');
+      if (data) printOutput(data, opts.output as OutputFormat);
+    });
+
+  cases
+    .command('detail')
+    .description('Get case detail by ID')
+    .argument('<id>', 'Case ID')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (id, opts) => {
+      const client = getClient();
+      const data = await client.caseDetail(Number.parseInt(id, 10));
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  cases
+    .command('detail-key')
+    .description('Get case detail by CaseKey')
+    .argument('<caseKey>', 'Case key')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (caseKey, opts) => {
+      const client = getClient();
+      const data = await client.caseDetailByKey(caseKey);
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  cases
+    .command('update')
+    .description('Update a case')
+    .argument('<id>', 'Case ID')
+    .option('--group-id <id>', 'Case group ID')
+    .option('-p, --priority <priority>', 'NONE, P0, P1, or P2')
+    .option('-s, --status <status>', 'todo, doing, or done')
+    .option('--assigner-id <id>', 'Assignee user ID')
+    .option('--description <text>', 'Case description')
+    .action(async (id, opts) => {
+      const client = getClient();
+      await client.caseUpdate(Number.parseInt(id, 10), {
+        groupId: opts.groupId ? Number.parseInt(opts.groupId, 10) : undefined,
+        priority: opts.priority,
+        status: opts.status,
+        assignerId: opts.assignerId
+          ? Number.parseInt(opts.assignerId, 10)
+          : undefined,
+        description: opts.description,
+      });
+      console.log('Case updated');
+    });
+
+  cases
+    .command('delete')
+    .description('Delete a case')
+    .argument('<id>', 'Case ID')
+    .action(async (id) => {
+      const client = getClient();
+      await client.caseDelete(Number.parseInt(id, 10));
+      console.log('Case deleted');
+    });
+
+  cases
+    .command('link')
+    .description('Link an alert or issue to a case')
+    .argument('<id>', 'Case ID')
+    .requiredOption('--type <type>', 'Relation type: alert or issue')
+    .requiredOption('--target-id <id>', 'Alert ID or Issue ID')
+    .action(async (id, opts) => {
+      const client = getClient();
+      await client.caseAddRelation(Number.parseInt(id, 10), {
+        type: opts.type,
+        targetId: opts.targetId,
+      });
+      console.log('Case relation added');
+    });
+
+  cases
+    .command('unlink')
+    .description('Remove a case relation')
+    .argument('<id>', 'Case ID')
+    .argument('<relationId>', 'Relation ID')
+    .action(async (id, relationId) => {
+      const client = getClient();
+      await client.caseDeleteRelation(
+        Number.parseInt(id, 10),
+        Number.parseInt(relationId, 10)
+      );
+      console.log('Case relation removed');
+    });
+
+  cases
+    .command('note')
+    .description('Add a case note')
+    .argument('<id>', 'Case ID')
+    .requiredOption('--text <text>', 'Note text')
+    .action(async (id, opts) => {
+      const client = getClient();
+      await client.caseAddNote(Number.parseInt(id, 10), opts.text);
+      console.log('Case note added');
+    });
+
+  cases
+    .command('note-update')
+    .description('Update a case note')
+    .argument('<id>', 'Case ID')
+    .argument('<noteId>', 'Note ID')
+    .requiredOption('--text <text>', 'Note text')
+    .action(async (id, noteId, opts) => {
+      const client = getClient();
+      await client.caseUpdateNote(
+        Number.parseInt(id, 10),
+        Number.parseInt(noteId, 10),
+        opts.text
+      );
+      console.log('Case note updated');
+    });
+
+  cases
+    .command('groups')
+    .description('List case groups')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (opts) => {
+      const client = getClient();
+      const data = await client.caseGroupsAll();
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  cases
+    .command('group-create')
+    .description('Create a case group')
+    .requiredOption('--name <name>', 'Case group name')
+    .action(async (opts) => {
+      const client = getClient();
+      await client.caseGroupCreate({ name: opts.name });
+      console.log('Case group created');
+    });
+
   // ─── trace ───────────────────────────────────────────────
   const trace = program.command('trace').description('Trace operations');
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OctoClient } from './client.js';
+import { getMcpTools, handleMcpTool } from './mcp.js';
+
+function captureFetch(data: unknown = null) {
+  const calls: {
+    url: string;
+    method: string;
+    body: string;
+    headers: Record<string, string>;
+  }[] = [];
+  const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({
+      url,
+      method: init.method ?? 'GET',
+      body: (init.body as string) ?? '',
+      headers: (init.headers as Record<string, string>) ?? {},
+    });
+    return new Response(JSON.stringify({ code: 0, data, message: 'ok' }));
+  });
+  vi.stubGlobal('fetch', mockFetch);
+  return calls;
+}
+
+function testClient() {
+  return new OctoClient('https://example.com', {
+    mode: 'appKey',
+    appId: 'testId',
+    appSecret: 'testSecret',
+  });
+}
+
+describe('MCP tools', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('lists CLI-backed tools that were missing from MCP', () => {
+    const tools = getMcpTools();
+    const toolNames = tools.map((tool) => tool.name);
+
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'octo_issues_detail',
+        'octo_issues_assign',
+        'octo_issues_update',
+        'octo_trace_aggregate',
+        'octo_metrics_point',
+        'octo_services_entries',
+        'octo_rum_detail',
+        'octo_users_search',
+        'octo_cases_create',
+        'octo_cases_link',
+      ])
+    );
+    const metricsPoint = tools.find(
+      (tool) => tool.name === 'octo_metrics_point'
+    );
+    const atProp = metricsPoint?.inputSchema.properties.at;
+    expect(atProp).toBeDefined();
+    expect((atProp as { type: string[] }).type).toEqual(['number', 'string']);
+  });
+
+  it('dispatches issue detail, assign, and update tools', async () => {
+    vi.stubEnv('OCTOPUS_ENV', 'default-env');
+    const client = testClient();
+    const calls = captureFetch();
+
+    await handleMcpTool('octo_issues_detail', { issueId: 'ISSUE-1' }, client);
+    await handleMcpTool(
+      'octo_issues_assign',
+      { userId: 123, issueIds: ['ISSUE-1', 'ISSUE-2'] },
+      client
+    );
+    await handleMcpTool(
+      'octo_issues_update',
+      { issueIds: ['ISSUE-1'], status: 'resolved' },
+      client
+    );
+
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/ISSUE-1'
+    );
+    expect(calls[1].method).toBe('POST');
+    expect(calls[1].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/batch-assign'
+    );
+    expect(JSON.parse(calls[1].body)).toEqual({
+      assigneeId: 123,
+      dataSource: 'log',
+      issueIds: ['ISSUE-1', 'ISSUE-2'],
+    });
+    expect(calls[2].method).toBe('PUT');
+    expect(calls[2].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/batch-update'
+    );
+    expect(JSON.parse(calls[2].body)).toEqual({
+      dataSource: 'log',
+      env: 'default-env',
+      issueIds: ['ISSUE-1'],
+      status: 'resolved',
+    });
+  });
+
+  it('dispatches trace aggregate and metrics point tools', async () => {
+    const client = testClient();
+    const calls = captureFetch();
+
+    await handleMcpTool(
+      'octo_trace_aggregate',
+      {
+        env: 'test',
+        from: 1000,
+        to: 2000,
+        aggregation_field: 'duration',
+        aggregation_op: 'avg',
+        group_by: 'service',
+        group_limit: 5,
+      },
+      client
+    );
+    await handleMcpTool(
+      'octo_metrics_point',
+      { env: 'test', at: '3000', queries: ['sum(cpu.usage{service=api})'] },
+      client
+    );
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/trace/aggregate'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      env: 'test',
+      from: 1000,
+      to: 2000,
+      aggregationFields: [{ field: 'duration', operation: 'avg' }],
+      groupFields: [
+        {
+          field: 'service',
+          limit: 5,
+          sort: { field: 'duration', operation: 'avg', order: 'desc' },
+        },
+      ],
+    });
+    expect(calls[1].method).toBe('POST');
+    expect(calls[1].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/metrics/query/queryMetric'
+    );
+    expect(JSON.parse(calls[1].body)).toEqual({
+      env: 'test',
+      to: 3000,
+      queries: [
+        {
+          id: 'A',
+          query: 'sum(cpu.usage{service=api})',
+          dataSource: 'metric',
+        },
+      ],
+    });
+  });
+
+  it('dispatches service entries, RUM detail, and user search tools', async () => {
+    const client = testClient();
+    const calls = captureFetch();
+
+    await handleMcpTool(
+      'octo_services_entries',
+      { env: 'test', from: 1000, to: 2000, service: 'checkout' },
+      client
+    );
+    await handleMcpTool('octo_rum_detail', { id: 'rum-event-1' }, client);
+    await handleMcpTool(
+      'octo_users_search',
+      { names: ['alice', 'bob'] },
+      client
+    );
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/apm/query/entries'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      env: 'test',
+      from: 1000,
+      to: 2000,
+      service: 'checkout',
+    });
+    expect(calls[1].method).toBe('GET');
+    expect(calls[1].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/rum/rum-event-1'
+    );
+    expect(calls[2].method).toBe('POST');
+    expect(calls[2].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/users/search'
+    );
+    expect(JSON.parse(calls[2].body)).toEqual({
+      names: ['alice', 'bob'],
+    });
+  });
+
+  it('dispatches representative case create and link tools', async () => {
+    const client = testClient();
+    const calls = captureFetch();
+
+    await handleMcpTool(
+      'octo_cases_create',
+      {
+        name: 'checkout incident',
+        groupId: 7,
+        priority: 'P1',
+        status: 'doing',
+        assignerId: 42,
+        description: 'investigate checkout failures',
+      },
+      client
+    );
+    await handleMcpTool(
+      'octo_cases_link',
+      { id: 99, type: 'alert', targetId: '12345' },
+      client
+    );
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      name: 'checkout incident',
+      groupId: 7,
+      priority: 'P1',
+      status: 'doing',
+      assignerId: 42,
+      description: 'investigate checkout failures',
+    });
+    expect(calls[1].method).toBe('POST');
+    expect(calls[1].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/cases/99/relation'
+    );
+    expect(JSON.parse(calls[1].body)).toEqual({
+      type: 'alert',
+      targetId: '12345',
+    });
+  });
+});

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -32,6 +32,7 @@ function testClient() {
 
 describe('MCP tools', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
@@ -197,6 +198,31 @@ describe('MCP tools', () => {
     );
     expect(JSON.parse(calls[2].body)).toEqual({
       names: ['alice', 'bob'],
+    });
+  });
+
+  it('defaults service entries to the CLI 1h time window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-03T12:00:00.000Z'));
+    vi.stubEnv('OCTOPUS_ENV', 'default-env');
+    const client = testClient();
+    const calls = captureFetch();
+
+    await handleMcpTool(
+      'octo_services_entries',
+      { service: 'checkout' },
+      client
+    );
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/apm/query/entries'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      env: 'default-env',
+      from: 1_783_076_400_000,
+      to: 1_783_080_000_000,
+      service: 'checkout',
     });
   });
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -52,6 +52,11 @@ const fromProp = {
   description:
     'Start time in epoch milliseconds. If omitted, the tool defaults to the last 15 minutes; for "last 1h", pass now-3600000.',
 };
+const serviceFromProp = {
+  type: 'number',
+  description:
+    'Start time in epoch milliseconds. If omitted, defaults to the last 1 hour to match the CLI services commands.',
+};
 const toProp = {
   type: 'number',
   description: 'End time in epoch milliseconds. If omitted, defaults to now.',
@@ -81,11 +86,27 @@ function timeDefaults(args: Record<string, unknown>): {
   env: string;
   from: number;
   to: number;
+};
+function timeDefaults(
+  args: Record<string, unknown>,
+  defaultWindowMs: number
+): {
+  env: string;
+  from: number;
+  to: number;
+};
+function timeDefaults(
+  args: Record<string, unknown>,
+  defaultWindowMs = 15 * 60_000
+): {
+  env: string;
+  from: number;
+  to: number;
 } {
   const now = Date.now();
   return {
     env: String(args.env ?? getDefaultEnv()),
-    from: Number(args.from ?? now - 15 * 60_000),
+    from: Number(args.from ?? now - defaultWindowMs),
     to: Number(args.to ?? now),
   };
 }
@@ -715,7 +736,7 @@ export function getMcpTools() {
         type: 'object' as const,
         properties: {
           env: envProp,
-          from: fromProp,
+          from: serviceFromProp,
           to: toProp,
         },
       },
@@ -727,7 +748,7 @@ export function getMcpTools() {
         type: 'object' as const,
         properties: {
           env: envProp,
-          from: fromProp,
+          from: serviceFromProp,
           to: toProp,
           service: {
             type: 'string',
@@ -1174,13 +1195,13 @@ export async function handleMcpTool(
       }
 
       case 'octo_services_list': {
-        const { env, from, to } = timeDefaults(args);
+        const { env, from, to } = timeDefaults(args, 60 * 60_000);
         const data = await client.servicesList({ env, from, to });
         return ok(JSON.stringify(data, null, 2));
       }
 
       case 'octo_services_entries': {
-        const { env, from, to } = timeDefaults(args);
+        const { env, from, to } = timeDefaults(args, 60 * 60_000);
         const data = await client.servicesEntries({
           env,
           from,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -61,6 +61,21 @@ const queryProp = {
   description:
     'Octopus search syntax, not Lucene/Elasticsearch. Field filters use `field = value`, `!=`, `>`, `>=`, `<`, `<=`, `in (...)`, `not in (...)`; do not use `field:value`. Values and field names are case-sensitive, operators AND/OR/NOT are case-insensitive. Use parentheses for grouping and double quotes for exact phrases. Wildcards only work in field search, e.g. `service = web*`. Common fields: service, level (FATAL/ERROR/WARN/INFO/DEBUG/TRACE), host, trace_id, issue_id, k8s.pod.name, source. Examples: `level = ERROR`, `service = octopus-query-proxy`, `service = myapp AND level = ERROR`, `(level = ERROR OR level = WARN) AND service = myapp`.',
 };
+const caseStatusProp = {
+  type: 'string',
+  description: 'Case status: todo, doing, or done',
+  enum: ['todo', 'doing', 'done'],
+};
+const casePriorityProp = {
+  type: 'string',
+  description: 'Case priority: NONE, P0, P1, or P2',
+  enum: ['NONE', 'P0', 'P1', 'P2'],
+};
+const caseRelationTypeProp = {
+  type: 'string',
+  description: 'Case relation type: alert or issue',
+  enum: ['alert', 'issue'],
+};
 
 function timeDefaults(args: Record<string, unknown>): {
   env: string;
@@ -75,6 +90,1171 @@ function timeDefaults(args: Record<string, unknown>): {
   };
 }
 
+function parsePointInTime(value: unknown): number {
+  if (value == null) return Date.now();
+  if (typeof value === 'number') return value;
+
+  const text = String(value);
+  if (/^\d+$/.test(text)) return Number(text);
+
+  return new Date(text).getTime();
+}
+
+export function getMcpTools() {
+  return [
+    {
+      name: 'octo_logs_search',
+      description:
+        'Search Octopus logs. Returns log entries with message, level, attributes, traceId.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          limit: {
+            type: 'number',
+            description: 'Max results (default 50, max 500)',
+          },
+          order: {
+            type: 'string',
+            description: 'asc or desc',
+            enum: ['asc', 'desc'],
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_logs_aggregate',
+      description:
+        'Aggregate Octopus logs — count, avg, max, min, sum, percentile, grouped by fields.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          aggregation_field: {
+            type: 'string',
+            description: 'Field to aggregate (use "*" for count)',
+          },
+          aggregation_op: {
+            type: 'string',
+            description: 'Operation: count, sum, avg, max, min, p50, p95, p99',
+          },
+          group_by: {
+            type: 'string',
+            description: 'Field to group by (e.g. "service", "level")',
+          },
+          group_limit: {
+            type: 'number',
+            description: 'Max groups (default 10)',
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_alerts_search',
+      description:
+        'Search Octopus alerts. Filter by status (firing/resolved), priority (P0/P1/P2), services.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          status: {
+            type: 'string',
+            description: 'all, firing, or resolved',
+            enum: ['all', 'firing', 'resolved'],
+          },
+          priorities: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Priority filter, e.g. ["P0","P1"]',
+          },
+          services: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Service name filter',
+          },
+          limit: { type: 'number', description: 'Max results' },
+          groupId: {
+            type: 'number',
+            description: 'Alert rule group ID',
+          },
+          ruleIds: {
+            type: 'array',
+            items: { type: 'number' },
+            description: 'Filter by specific alert rule IDs',
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_alerts_rules_search',
+      description:
+        'Search Octopus alert rules. Filter by group, env, priority, status, type, tags, creator.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          groupId: {
+            type: 'number',
+            description: 'Alert rule group ID (-1 for all groups)',
+          },
+          env: envProp,
+          priority: {
+            type: 'string',
+            description: 'Priority filter: P0, P1, P2',
+          },
+          statusList: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Status filter: enabled, disabled, paused, silenced',
+          },
+          searchInput: {
+            type: 'string',
+            description: 'Search keyword for rule name',
+          },
+          types: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Rule type filter: log, metric, issue, rum, llm',
+          },
+          service: { type: 'string', description: 'Service name filter' },
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Tag filter',
+          },
+          creator: { type: 'string', description: 'Creator name filter' },
+          pageNo: { type: 'number', description: 'Page number (default 1)' },
+          pageSize: {
+            type: 'number',
+            description: 'Page size (default 20)',
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_alerts_rules_create',
+      description:
+        'Create Octopus alert rules. Accepts an array of rule objects. ' +
+        'Each rule needs: name, env, groupId, ruleType (log/metric/issue/rum/llm), ' +
+        'priority (P0/P1/P2/UNKNOWN), conditionEvaluationType (single/and/or), ' +
+        'conditions (array with period, comparison, threshold, alertQueryInfo), ' +
+        'notice (receivers, repeatNoticeInterval, effectiveWeeks, etc.), tags, active. ' +
+        'Tip: use octo_alerts_rules_search to find existing rules as payload templates.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          rules: {
+            type: 'array',
+            items: { type: 'object' },
+            description:
+              'Array of alert rule objects (AlertRuleCreateVO). See tool description for required fields.',
+          },
+        },
+        required: ['rules'],
+      },
+    },
+    {
+      name: 'octo_alerts_rules_delete',
+      description: 'Delete an Octopus alert rule by ID.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          ruleId: {
+            type: 'number',
+            description: 'Alert rule ID to delete',
+          },
+        },
+        required: ['ruleId'],
+      },
+    },
+    {
+      name: 'octo_alerts_detail',
+      description:
+        'Get Octopus alert detail including rule conditions, trigger dimensions, and status.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          alertId: {
+            type: 'number',
+            description: 'Alert ID',
+          },
+        },
+        required: ['alertId'],
+      },
+    },
+    {
+      name: 'octo_alerts_timeseries',
+      description:
+        'Get Octopus alert detection timeseries data (time points, values, labels, condition status).',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          alertId: {
+            type: 'number',
+            description: 'Alert ID',
+          },
+          from: fromProp,
+          to: toProp,
+          conditionId: {
+            type: 'number',
+            description: 'Condition ID (default 0 for first condition)',
+          },
+        },
+        required: ['alertId'],
+      },
+    },
+    {
+      name: 'octo_alerts_silence_create',
+      description:
+        'Create an alert silence (mute) in Octopus. Suppresses notifications for a rule during a time window.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          ruleId: {
+            type: 'number',
+            description: 'Alert rule ID to silence',
+          },
+          alertId: {
+            type: 'number',
+            description: 'Specific alert ID to silence',
+          },
+          durationMinutes: {
+            type: 'number',
+            description:
+              'Silence duration in minutes (e.g. 120 for 2 hours). Alternative to endTime.',
+          },
+          startTime: {
+            type: 'number',
+            description: 'Silence start time in epoch ms (default: now)',
+          },
+          endTime: {
+            type: 'number',
+            description:
+              'Silence end time in epoch ms. Required if durationMinutes is not set.',
+          },
+          scope: {
+            type: 'string',
+            description: 'Silence scope',
+            enum: ['ALL', 'SPECIFY'],
+          },
+          specifyGroups: {
+            type: 'object',
+            description:
+              'When scope=specify, map of group field to values array',
+          },
+          silentlyNotify: {
+            type: 'boolean',
+            description: 'Whether to send notification about the silence',
+          },
+        },
+        required: ['ruleId', 'alertId'],
+      },
+    },
+    {
+      name: 'octo_alerts_silence_delete',
+      description: 'Delete (cancel) an alert silence in Octopus.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          ruleId: {
+            type: 'number',
+            description: 'Alert rule ID whose silence to remove',
+          },
+        },
+        required: ['ruleId'],
+      },
+    },
+    {
+      name: 'octo_issues_search',
+      description:
+        'Search Octopus error tracking issues. Returns error type, count, service, status.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          status: {
+            type: 'string',
+            description: 'unresolved, resolved, ignored, or all',
+            enum: ['unresolved', 'resolved', 'ignored', 'all'],
+          },
+          sort_type: {
+            type: 'string',
+            description: 'logCount or firstSeen',
+            enum: ['logCount', 'firstSeen'],
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_issues_detail',
+      description: 'Get Octopus error tracking issue detail by issue ID.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          issueId: { type: 'string', description: 'Issue ID' },
+        },
+        required: ['issueId'],
+      },
+    },
+    {
+      name: 'octo_issues_assign',
+      description: 'Batch assign Octopus error tracking issues to a user.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          userId: { type: 'number', description: 'Assignee user ID' },
+          issueIds: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Issue IDs to assign',
+          },
+          dataSource: {
+            type: 'string',
+            description: 'Data source: log or rum (default log)',
+          },
+        },
+        required: ['userId', 'issueIds'],
+      },
+    },
+    {
+      name: 'octo_issues_update',
+      description: 'Batch update Octopus error tracking issue status.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          issueIds: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Issue IDs to update',
+          },
+          status: {
+            type: 'string',
+            description: 'unresolved, resolved, or ignored',
+            enum: ['unresolved', 'resolved', 'ignored'],
+          },
+          env: envProp,
+          dataSource: {
+            type: 'string',
+            description: 'Data source: log or rum (default log)',
+          },
+        },
+        required: ['issueIds', 'status'],
+      },
+    },
+    {
+      name: 'octo_cases_list',
+      description:
+        'List Octopus cases. Filter by group, status, priority, assignee, or case name input.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          groupId: { type: 'number', description: 'Case group ID' },
+          status: caseStatusProp,
+          priority: casePriorityProp,
+          assignerId: { type: 'number', description: 'Assignee user ID' },
+          input: { type: 'string', description: 'Search by case name' },
+          pageNo: { type: 'number', description: 'Page number (default 1)' },
+          pageSize: {
+            type: 'number',
+            description: 'Page size (default 20, max 1000)',
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_cases_create',
+      description: 'Create an Octopus case.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          name: { type: 'string', description: 'Case name' },
+          groupId: { type: 'number', description: 'Case group ID' },
+          priority: casePriorityProp,
+          status: caseStatusProp,
+          assignerId: { type: 'number', description: 'Assignee user ID' },
+          description: { type: 'string', description: 'Case description' },
+        },
+        required: ['name', 'groupId'],
+      },
+    },
+    {
+      name: 'octo_cases_detail',
+      description:
+        'Get Octopus case detail by numeric ID, including relations and timeline.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+        },
+        required: ['id'],
+      },
+    },
+    {
+      name: 'octo_cases_detail_by_key',
+      description:
+        'Get Octopus case detail by CaseKey, including relations and timeline.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          caseKey: { type: 'string', description: 'Case key' },
+        },
+        required: ['caseKey'],
+      },
+    },
+    {
+      name: 'octo_cases_update',
+      description: 'Update editable fields on an Octopus case.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+          groupId: { type: 'number', description: 'Case group ID' },
+          priority: casePriorityProp,
+          status: caseStatusProp,
+          assignerId: { type: 'number', description: 'Assignee user ID' },
+          description: { type: 'string', description: 'Case description' },
+        },
+        required: ['id'],
+      },
+    },
+    {
+      name: 'octo_cases_delete',
+      description: 'Delete an Octopus case by ID.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+        },
+        required: ['id'],
+      },
+    },
+    {
+      name: 'octo_cases_link',
+      description: 'Link an alert or issue to an Octopus case.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+          type: caseRelationTypeProp,
+          targetId: {
+            type: 'string',
+            description:
+              'Alert ID when type=alert, or Issue ID when type=issue',
+          },
+        },
+        required: ['id', 'type', 'targetId'],
+      },
+    },
+    {
+      name: 'octo_cases_unlink',
+      description: 'Remove a relation from an Octopus case.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+          relationId: { type: 'number', description: 'Relation ID' },
+        },
+        required: ['id', 'relationId'],
+      },
+    },
+    {
+      name: 'octo_cases_note_add',
+      description: 'Add a note to an Octopus case.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+          text: { type: 'string', description: 'Note text' },
+        },
+        required: ['id', 'text'],
+      },
+    },
+    {
+      name: 'octo_cases_note_update',
+      description: 'Update a note on an Octopus case.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'number', description: 'Case ID' },
+          noteId: { type: 'number', description: 'Note ID' },
+          text: { type: 'string', description: 'Note text' },
+        },
+        required: ['id', 'noteId', 'text'],
+      },
+    },
+    {
+      name: 'octo_cases_groups_all',
+      description: 'List all Octopus case groups.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {},
+      },
+    },
+    {
+      name: 'octo_cases_group_create',
+      description: 'Create an Octopus case group.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          name: { type: 'string', description: 'Case group name' },
+        },
+        required: ['name'],
+      },
+    },
+    {
+      name: 'octo_trace_search',
+      description:
+        'Search Octopus trace spans. Returns span name, service, duration, status, traceId.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          limit: { type: 'number', description: 'Max results (max 500)' },
+          order: {
+            type: 'string',
+            enum: ['asc', 'desc'],
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_trace_aggregate',
+      description:
+        'Aggregate Octopus trace spans — count, avg, max, min, sum, percentile, grouped by fields.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          aggregation_field: {
+            type: 'string',
+            description: 'Field to aggregate (use "*" for count)',
+          },
+          aggregation_op: {
+            type: 'string',
+            description: 'Operation: count, sum, avg, max, min, p50, p95, p99',
+          },
+          group_by: {
+            type: 'string',
+            description: 'Field to group by (e.g. "service", "operation")',
+          },
+          group_limit: {
+            type: 'number',
+            description: 'Max groups (default 10)',
+          },
+        },
+      },
+    },
+    {
+      name: 'octo_metrics_query',
+      description:
+        'Query Octopus metrics timeseries. Use metric query syntax like "sum(metric_name{tag=value}.as_count)".',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          queries: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Metric query strings, e.g. ["sum(http_requests{service=myapp}.as_count)"]',
+          },
+          point_count: {
+            type: 'number',
+            description: 'Number of data points (default 150)',
+          },
+        },
+        required: ['queries'],
+      },
+    },
+    {
+      name: 'octo_metrics_point',
+      description:
+        'Query Octopus metrics at one point in time. Use metric query syntax like "sum(metric_name{tag=value}.as_count)".',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          at: {
+            type: ['number', 'string'],
+            description:
+              'Point-in-time as epoch milliseconds or ISO string. Defaults to now.',
+          },
+          queries: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Metric query strings, e.g. ["sum(http_requests{service=myapp}.as_count)"]',
+          },
+        },
+        required: ['queries'],
+      },
+    },
+    {
+      name: 'octo_services_list',
+      description: 'List Octopus APM services.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+        },
+      },
+    },
+    {
+      name: 'octo_services_entries',
+      description: 'List Octopus APM service entries for a service.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          service: {
+            type: 'string',
+            description: 'Service name',
+          },
+        },
+        required: ['service'],
+      },
+    },
+    {
+      name: 'octo_services_topology',
+      description:
+        'Get service call topology graph — upstream/downstream services and edges.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          service: {
+            type: 'string',
+            description: 'Service name',
+          },
+        },
+        required: ['service'],
+      },
+    },
+    {
+      name: 'octo_llm_list',
+      description:
+        'Query Octopus LLM observability spans — model, tokens, cost, duration.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          limit: { type: 'number', description: 'Page size' },
+        },
+      },
+    },
+    {
+      name: 'octo_rum_list',
+      description:
+        'Query Octopus RUM (Real User Monitoring) events — sessions, views, actions, errors.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          limit: { type: 'number', description: 'Page size' },
+        },
+      },
+    },
+    {
+      name: 'octo_rum_detail',
+      description: 'Get Octopus RUM event detail by event ID.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          id: { type: 'string', description: 'RUM event ID' },
+        },
+        required: ['id'],
+      },
+    },
+    {
+      name: 'octo_events_list',
+      description:
+        'Query Octopus events — deployments, config changes, incidents.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          env: envProp,
+          from: fromProp,
+          to: toProp,
+          query: queryProp,
+          limit: { type: 'number', description: 'Page size' },
+        },
+      },
+    },
+    {
+      name: 'octo_users_search',
+      description: 'Search Octopus users by names.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          names: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'User names to search',
+          },
+        },
+        required: ['names'],
+      },
+    },
+  ];
+}
+
+export async function handleMcpTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OctoClient = getClient()
+) {
+  try {
+    switch (name) {
+      case 'octo_logs_search': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.logsSearch({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          limit: args.limit as number | undefined,
+          order: args.order as string | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_logs_aggregate': {
+        const { env, from, to } = timeDefaults(args);
+        const aggField = String(args.aggregation_field ?? '*');
+        const aggOp = String(args.aggregation_op ?? 'count');
+        const groupBy = args.group_by as string | undefined;
+        const groupLimit = Number(args.group_limit ?? 10);
+
+        const data = await client.logsAggregate({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          aggregationFields: [{ field: aggField, operation: aggOp }],
+          groupFields: groupBy
+            ? [
+                {
+                  field: groupBy,
+                  limit: groupLimit,
+                  sort: { field: aggField, operation: aggOp, order: 'desc' },
+                },
+              ]
+            : undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_search': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.alertsSearch({
+          from,
+          to,
+          env,
+          status: (args.status as string) ?? 'all',
+          priorities: args.priorities as string[] | undefined,
+          services: args.services as string[] | undefined,
+          limit: args.limit as number | undefined,
+          groupId: args.groupId as number | undefined,
+          ruleIds: args.ruleIds as number[] | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_rules_search': {
+        const data = await client.alertRulesSearch({
+          groupId: (args.groupId as number) ?? -1,
+          env: args.env as string | undefined,
+          priority: args.priority as string | undefined,
+          statusList: args.statusList as string[] | undefined,
+          searchInput: args.searchInput as string | undefined,
+          types: args.types as string[] | undefined,
+          service: args.service as string | undefined,
+          tags: args.tags as string[] | undefined,
+          creator: args.creator as string | undefined,
+          pageParam: {
+            pageNo: (args.pageNo as number) ?? 1,
+            pageSize: (args.pageSize as number) ?? 20,
+          },
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_rules_create': {
+        const rules = args.rules as unknown[];
+        if (!Array.isArray(rules) || rules.length === 0) {
+          return fail('rules must be a non-empty array');
+        }
+        const data = await client.alertRulesCreate(rules);
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_rules_delete': {
+        const ruleId = args.ruleId as number;
+        await client.alertRulesDelete(ruleId);
+        return ok(`Alert rule ${ruleId} deleted`);
+      }
+
+      case 'octo_alerts_detail': {
+        const data = await client.alertDetail(args.alertId as number);
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_timeseries': {
+        const { from, to } = timeDefaults(args);
+        const data = await client.alertTimeseries({
+          alertId: args.alertId as number,
+          from,
+          to,
+          conditionId: args.conditionId as number | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_silence_create': {
+        const now = Date.now();
+        const startTime = (args.startTime as number) ?? now;
+        let endTime = args.endTime as number | undefined;
+        if (!endTime && args.durationMinutes) {
+          endTime = startTime + (args.durationMinutes as number) * 60_000;
+        }
+        if (!endTime) {
+          return fail('Either endTime or durationMinutes is required');
+        }
+        const data = await client.alertSilenceCreate({
+          ruleId: args.ruleId as number,
+          alertId: args.alertId as number,
+          startTime,
+          endTime,
+          scope: (args.scope as string) ?? 'ALL',
+          specifyGroups: args.specifyGroups as
+            | Record<string, string[]>
+            | undefined,
+          silentlyNotify: (args.silentlyNotify as boolean) ?? false,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_silence_delete': {
+        const ruleId = args.ruleId as number;
+        await client.alertSilenceDelete(ruleId);
+        return ok(`Silence for rule ${ruleId} deleted`);
+      }
+
+      case 'octo_issues_search': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.issuesSearch({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          status: (args.status as string) ?? 'unresolved',
+          sortType: (args.sort_type as string) ?? 'logCount',
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_issues_detail': {
+        const data = await client.issueDetail(String(args.issueId));
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_issues_assign': {
+        await client.issuesBatchAssign({
+          assigneeId: args.userId as number,
+          dataSource: (args.dataSource as string) ?? 'log',
+          issueIds: args.issueIds as string[],
+        });
+        return ok('Issues assigned');
+      }
+
+      case 'octo_issues_update': {
+        await client.issuesBatchUpdate({
+          dataSource: (args.dataSource as string) ?? 'log',
+          env: String(args.env ?? getDefaultEnv()),
+          issueIds: args.issueIds as string[],
+          status: String(args.status),
+        });
+        return ok('Issues updated');
+      }
+
+      case 'octo_cases_list': {
+        const data = await client.casesList({
+          pageNo: (args.pageNo as number) ?? 1,
+          pageSize: (args.pageSize as number) ?? 20,
+          groupId: args.groupId as number | undefined,
+          status: args.status as string | undefined,
+          priority: args.priority as string | undefined,
+          assignerId: args.assignerId as number | undefined,
+          input: args.input as string | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_cases_create': {
+        const data = await client.caseCreate({
+          name: String(args.name),
+          groupId: args.groupId as number,
+          priority: args.priority as string | undefined,
+          status: args.status as string | undefined,
+          assignerId: args.assignerId as number | undefined,
+          description: args.description as string | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_cases_detail': {
+        const data = await client.caseDetail(args.id as number);
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_cases_detail_by_key': {
+        const data = await client.caseDetailByKey(String(args.caseKey));
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_cases_update': {
+        const id = args.id as number;
+        await client.caseUpdate(id, {
+          groupId: args.groupId as number | undefined,
+          priority: args.priority as string | undefined,
+          status: args.status as string | undefined,
+          assignerId: args.assignerId as number | undefined,
+          description: args.description as string | undefined,
+        });
+        return ok(`Case ${id} updated`);
+      }
+
+      case 'octo_cases_delete': {
+        const id = args.id as number;
+        await client.caseDelete(id);
+        return ok(`Case ${id} deleted`);
+      }
+
+      case 'octo_cases_link': {
+        const id = args.id as number;
+        await client.caseAddRelation(id, {
+          type: String(args.type),
+          targetId: String(args.targetId),
+        });
+        return ok(`Relation added to case ${id}`);
+      }
+
+      case 'octo_cases_unlink': {
+        const id = args.id as number;
+        const relationId = args.relationId as number;
+        await client.caseDeleteRelation(id, relationId);
+        return ok(`Relation ${relationId} removed from case ${id}`);
+      }
+
+      case 'octo_cases_note_add': {
+        const id = args.id as number;
+        await client.caseAddNote(id, String(args.text));
+        return ok(`Note added to case ${id}`);
+      }
+
+      case 'octo_cases_note_update': {
+        const id = args.id as number;
+        const noteId = args.noteId as number;
+        await client.caseUpdateNote(id, noteId, String(args.text));
+        return ok(`Note ${noteId} updated on case ${id}`);
+      }
+
+      case 'octo_cases_groups_all': {
+        const data = await client.caseGroupsAll();
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_cases_group_create': {
+        await client.caseGroupCreate({ name: String(args.name) });
+        return ok(`Case group "${String(args.name)}" created`);
+      }
+
+      case 'octo_trace_search': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.traceSpanList({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          limit: args.limit as number | undefined,
+          order: args.order as string | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_trace_aggregate': {
+        const { env, from, to } = timeDefaults(args);
+        const aggField = String(args.aggregation_field ?? '*');
+        const aggOp = String(args.aggregation_op ?? 'count');
+        const groupBy = args.group_by as string | undefined;
+        const groupLimit = Number(args.group_limit ?? 10);
+
+        const data = await client.traceAggregate({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          aggregationFields: [{ field: aggField, operation: aggOp }],
+          groupFields: groupBy
+            ? [
+                {
+                  field: groupBy,
+                  limit: groupLimit,
+                  sort: { field: aggField, operation: aggOp, order: 'desc' },
+                },
+              ]
+            : undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_metrics_query': {
+        const { env, from, to } = timeDefaults(args);
+        const queryStrs = args.queries as string[];
+        const queries = queryStrs.map((q, i) => ({
+          id: String.fromCharCode(65 + i),
+          query: q,
+          dataSource: 'metric',
+        }));
+        const data = await client.metricsTimeseries({
+          env,
+          from,
+          to,
+          pointCount: (args.point_count as number) ?? 150,
+          queries,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_metrics_point': {
+        const queryStrs = args.queries as string[];
+        const queries = queryStrs.map((q, i) => ({
+          id: String.fromCharCode(65 + i),
+          query: q,
+          dataSource: 'metric',
+        }));
+        const at = parsePointInTime(args.at);
+        const data = await client.metricsQuery({
+          env: String(args.env ?? getDefaultEnv()),
+          to: at,
+          queries,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_services_list': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.servicesList({ env, from, to });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_services_entries': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.servicesEntries({
+          env,
+          from,
+          to,
+          service: String(args.service),
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_services_topology': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.servicesTopology({
+          env,
+          from,
+          to,
+          service: String(args.service),
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_llm_list': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.llmList({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          pageSize: args.limit as number | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_rum_list': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.rumList({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          pageSize: args.limit as number | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_rum_detail': {
+        const data = await client.rumDetail(String(args.id));
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_events_list': {
+        const { env, from, to } = timeDefaults(args);
+        const data = await client.eventList({
+          env,
+          from,
+          to,
+          query: args.query as string | undefined,
+          pageSize: args.limit as number | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_users_search': {
+        const data = await client.usersSearch(args.names as string[]);
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      default:
+        return fail(`Unknown tool: ${name}`);
+    }
+  } catch (err) {
+    return fail(err);
+  }
+}
+
 export async function startMcpServer(): Promise<void> {
   const server = new Server(
     { name: 'octo-mcp', version: '0.1.0' },
@@ -82,668 +1262,12 @@ export async function startMcpServer(): Promise<void> {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [
-      {
-        name: 'octo_logs_search',
-        description:
-          'Search Octopus logs. Returns log entries with message, level, attributes, traceId.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            limit: {
-              type: 'number',
-              description: 'Max results (default 50, max 500)',
-            },
-            order: {
-              type: 'string',
-              description: 'asc or desc',
-              enum: ['asc', 'desc'],
-            },
-          },
-        },
-      },
-      {
-        name: 'octo_logs_aggregate',
-        description:
-          'Aggregate Octopus logs — count, avg, max, min, sum, percentile, grouped by fields.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            aggregation_field: {
-              type: 'string',
-              description: 'Field to aggregate (use "*" for count)',
-            },
-            aggregation_op: {
-              type: 'string',
-              description:
-                'Operation: count, sum, avg, max, min, p50, p95, p99',
-            },
-            group_by: {
-              type: 'string',
-              description: 'Field to group by (e.g. "service", "level")',
-            },
-            group_limit: {
-              type: 'number',
-              description: 'Max groups (default 10)',
-            },
-          },
-        },
-      },
-      {
-        name: 'octo_alerts_search',
-        description:
-          'Search Octopus alerts. Filter by status (firing/resolved), priority (P0/P1/P2), services.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            status: {
-              type: 'string',
-              description: 'all, firing, or resolved',
-              enum: ['all', 'firing', 'resolved'],
-            },
-            priorities: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Priority filter, e.g. ["P0","P1"]',
-            },
-            services: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Service name filter',
-            },
-            limit: { type: 'number', description: 'Max results' },
-            groupId: {
-              type: 'number',
-              description: 'Alert rule group ID',
-            },
-            ruleIds: {
-              type: 'array',
-              items: { type: 'number' },
-              description: 'Filter by specific alert rule IDs',
-            },
-          },
-        },
-      },
-      {
-        name: 'octo_alerts_rules_search',
-        description:
-          'Search Octopus alert rules. Filter by group, env, priority, status, type, tags, creator.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            groupId: {
-              type: 'number',
-              description: 'Alert rule group ID (-1 for all groups)',
-            },
-            env: envProp,
-            priority: {
-              type: 'string',
-              description: 'Priority filter: P0, P1, P2',
-            },
-            statusList: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Status filter: enabled, disabled, paused, silenced',
-            },
-            searchInput: {
-              type: 'string',
-              description: 'Search keyword for rule name',
-            },
-            types: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Rule type filter: log, metric, issue, rum, llm',
-            },
-            service: { type: 'string', description: 'Service name filter' },
-            tags: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Tag filter',
-            },
-            creator: { type: 'string', description: 'Creator name filter' },
-            pageNo: { type: 'number', description: 'Page number (default 1)' },
-            pageSize: {
-              type: 'number',
-              description: 'Page size (default 20)',
-            },
-          },
-        },
-      },
-      {
-        name: 'octo_alerts_rules_create',
-        description:
-          'Create Octopus alert rules. Accepts an array of rule objects. ' +
-          'Each rule needs: name, env, groupId, ruleType (log/metric/issue/rum/llm), ' +
-          'priority (P0/P1/P2/UNKNOWN), conditionEvaluationType (single/and/or), ' +
-          'conditions (array with period, comparison, threshold, alertQueryInfo), ' +
-          'notice (receivers, repeatNoticeInterval, effectiveWeeks, etc.), tags, active. ' +
-          'Tip: use octo_alerts_rules_search to find existing rules as payload templates.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            rules: {
-              type: 'array',
-              items: { type: 'object' },
-              description:
-                'Array of alert rule objects (AlertRuleCreateVO). See tool description for required fields.',
-            },
-          },
-          required: ['rules'],
-        },
-      },
-      {
-        name: 'octo_alerts_rules_delete',
-        description: 'Delete an Octopus alert rule by ID.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            ruleId: {
-              type: 'number',
-              description: 'Alert rule ID to delete',
-            },
-          },
-          required: ['ruleId'],
-        },
-      },
-      {
-        name: 'octo_alerts_detail',
-        description:
-          'Get Octopus alert detail including rule conditions, trigger dimensions, and status.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            alertId: {
-              type: 'number',
-              description: 'Alert ID',
-            },
-          },
-          required: ['alertId'],
-        },
-      },
-      {
-        name: 'octo_alerts_timeseries',
-        description:
-          'Get Octopus alert detection timeseries data (time points, values, labels, condition status).',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            alertId: {
-              type: 'number',
-              description: 'Alert ID',
-            },
-            from: fromProp,
-            to: toProp,
-            conditionId: {
-              type: 'number',
-              description: 'Condition ID (default 0 for first condition)',
-            },
-          },
-          required: ['alertId'],
-        },
-      },
-      {
-        name: 'octo_alerts_silence_create',
-        description:
-          'Create an alert silence (mute) in Octopus. Suppresses notifications for a rule during a time window.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            ruleId: {
-              type: 'number',
-              description: 'Alert rule ID to silence',
-            },
-            alertId: {
-              type: 'number',
-              description: 'Specific alert ID to silence',
-            },
-            durationMinutes: {
-              type: 'number',
-              description:
-                'Silence duration in minutes (e.g. 120 for 2 hours). Alternative to endTime.',
-            },
-            startTime: {
-              type: 'number',
-              description: 'Silence start time in epoch ms (default: now)',
-            },
-            endTime: {
-              type: 'number',
-              description:
-                'Silence end time in epoch ms. Required if durationMinutes is not set.',
-            },
-            scope: {
-              type: 'string',
-              description: 'Silence scope',
-              enum: ['ALL', 'SPECIFY'],
-            },
-            specifyGroups: {
-              type: 'object',
-              description:
-                'When scope=specify, map of group field to values array',
-            },
-            silentlyNotify: {
-              type: 'boolean',
-              description: 'Whether to send notification about the silence',
-            },
-          },
-          required: ['ruleId', 'alertId'],
-        },
-      },
-      {
-        name: 'octo_alerts_silence_delete',
-        description: 'Delete (cancel) an alert silence in Octopus.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            ruleId: {
-              type: 'number',
-              description: 'Alert rule ID whose silence to remove',
-            },
-          },
-          required: ['ruleId'],
-        },
-      },
-      {
-        name: 'octo_issues_search',
-        description:
-          'Search Octopus error tracking issues. Returns error type, count, service, status.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            status: {
-              type: 'string',
-              description: 'unresolved, resolved, ignored, or all',
-              enum: ['unresolved', 'resolved', 'ignored', 'all'],
-            },
-            sort_type: {
-              type: 'string',
-              description: 'logCount or firstSeen',
-              enum: ['logCount', 'firstSeen'],
-            },
-          },
-        },
-      },
-      {
-        name: 'octo_trace_search',
-        description:
-          'Search Octopus trace spans. Returns span name, service, duration, status, traceId.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            limit: { type: 'number', description: 'Max results (max 500)' },
-            order: {
-              type: 'string',
-              enum: ['asc', 'desc'],
-            },
-          },
-        },
-      },
-      {
-        name: 'octo_metrics_query',
-        description:
-          'Query Octopus metrics timeseries. Use metric query syntax like "sum(metric_name{tag=value}.as_count)".',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            queries: {
-              type: 'array',
-              items: { type: 'string' },
-              description:
-                'Metric query strings, e.g. ["sum(http_requests{service=myapp}.as_count)"]',
-            },
-            point_count: {
-              type: 'number',
-              description: 'Number of data points (default 150)',
-            },
-          },
-          required: ['queries'],
-        },
-      },
-      {
-        name: 'octo_services_list',
-        description: 'List Octopus APM services.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-          },
-        },
-      },
-      {
-        name: 'octo_services_topology',
-        description:
-          'Get service call topology graph — upstream/downstream services and edges.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            service: {
-              type: 'string',
-              description: 'Service name',
-            },
-          },
-          required: ['service'],
-        },
-      },
-      {
-        name: 'octo_llm_list',
-        description:
-          'Query Octopus LLM observability spans — model, tokens, cost, duration.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            limit: { type: 'number', description: 'Page size' },
-          },
-        },
-      },
-      {
-        name: 'octo_rum_list',
-        description:
-          'Query Octopus RUM (Real User Monitoring) events — sessions, views, actions, errors.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            limit: { type: 'number', description: 'Page size' },
-          },
-        },
-      },
-      {
-        name: 'octo_events_list',
-        description:
-          'Query Octopus events — deployments, config changes, incidents.',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            env: envProp,
-            from: fromProp,
-            to: toProp,
-            query: queryProp,
-            limit: { type: 'number', description: 'Page size' },
-          },
-        },
-      },
-    ],
+    tools: getMcpTools(),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const args = (request.params.arguments ?? {}) as Record<string, unknown>;
-
-    try {
-      const client = getClient();
-
-      switch (request.params.name) {
-        case 'octo_logs_search': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.logsSearch({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            limit: args.limit as number | undefined,
-            order: args.order as string | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_logs_aggregate': {
-          const { env, from, to } = timeDefaults(args);
-          const aggField = String(args.aggregation_field ?? '*');
-          const aggOp = String(args.aggregation_op ?? 'count');
-          const groupBy = args.group_by as string | undefined;
-          const groupLimit = Number(args.group_limit ?? 10);
-
-          const data = await client.logsAggregate({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            aggregationFields: [{ field: aggField, operation: aggOp }],
-            groupFields: groupBy
-              ? [
-                  {
-                    field: groupBy,
-                    limit: groupLimit,
-                    sort: { field: aggField, operation: aggOp, order: 'desc' },
-                  },
-                ]
-              : undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_search': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.alertsSearch({
-            from,
-            to,
-            env,
-            status: (args.status as string) ?? 'all',
-            priorities: args.priorities as string[] | undefined,
-            services: args.services as string[] | undefined,
-            limit: args.limit as number | undefined,
-            groupId: args.groupId as number | undefined,
-            ruleIds: args.ruleIds as number[] | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_rules_search': {
-          const data = await client.alertRulesSearch({
-            groupId: (args.groupId as number) ?? -1,
-            env: args.env as string | undefined,
-            priority: args.priority as string | undefined,
-            statusList: args.statusList as string[] | undefined,
-            searchInput: args.searchInput as string | undefined,
-            types: args.types as string[] | undefined,
-            service: args.service as string | undefined,
-            tags: args.tags as string[] | undefined,
-            creator: args.creator as string | undefined,
-            pageParam: {
-              pageNo: (args.pageNo as number) ?? 1,
-              pageSize: (args.pageSize as number) ?? 20,
-            },
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_rules_create': {
-          const rules = args.rules as unknown[];
-          if (!Array.isArray(rules) || rules.length === 0) {
-            return fail('rules must be a non-empty array');
-          }
-          const data = await client.alertRulesCreate(rules);
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_rules_delete': {
-          const ruleId = args.ruleId as number;
-          await client.alertRulesDelete(ruleId);
-          return ok(`Alert rule ${ruleId} deleted`);
-        }
-
-        case 'octo_alerts_detail': {
-          const data = await client.alertDetail(args.alertId as number);
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_timeseries': {
-          const { from, to } = timeDefaults(args);
-          const data = await client.alertTimeseries({
-            alertId: args.alertId as number,
-            from,
-            to,
-            conditionId: args.conditionId as number | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_silence_create': {
-          const now = Date.now();
-          const startTime = (args.startTime as number) ?? now;
-          let endTime = args.endTime as number | undefined;
-          if (!endTime && args.durationMinutes) {
-            endTime = startTime + (args.durationMinutes as number) * 60_000;
-          }
-          if (!endTime) {
-            return fail('Either endTime or durationMinutes is required');
-          }
-          const data = await client.alertSilenceCreate({
-            ruleId: args.ruleId as number,
-            alertId: args.alertId as number,
-            startTime,
-            endTime,
-            scope: (args.scope as string) ?? 'ALL',
-            specifyGroups: args.specifyGroups as
-              | Record<string, string[]>
-              | undefined,
-            silentlyNotify: (args.silentlyNotify as boolean) ?? false,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_alerts_silence_delete': {
-          const ruleId = args.ruleId as number;
-          await client.alertSilenceDelete(ruleId);
-          return ok(`Silence for rule ${ruleId} deleted`);
-        }
-
-        case 'octo_issues_search': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.issuesSearch({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            status: (args.status as string) ?? 'unresolved',
-            sortType: (args.sort_type as string) ?? 'logCount',
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_trace_search': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.traceSpanList({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            limit: args.limit as number | undefined,
-            order: args.order as string | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_metrics_query': {
-          const { env, from, to } = timeDefaults(args);
-          const queryStrs = args.queries as string[];
-          const queries = queryStrs.map((q, i) => ({
-            id: String.fromCharCode(65 + i),
-            query: q,
-            dataSource: 'metric',
-          }));
-          const data = await client.metricsTimeseries({
-            env,
-            from,
-            to,
-            pointCount: (args.point_count as number) ?? 150,
-            queries,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_services_list': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.servicesList({ env, from, to });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_services_topology': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.servicesTopology({
-            env,
-            from,
-            to,
-            service: String(args.service),
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_llm_list': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.llmList({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            pageSize: args.limit as number | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_rum_list': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.rumList({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            pageSize: args.limit as number | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        case 'octo_events_list': {
-          const { env, from, to } = timeDefaults(args);
-          const data = await client.eventList({
-            env,
-            from,
-            to,
-            query: args.query as string | undefined,
-            pageSize: args.limit as number | undefined,
-          });
-          return ok(JSON.stringify(data, null, 2));
-        }
-
-        default:
-          return fail(`Unknown tool: ${request.params.name}`);
-      }
-    } catch (err) {
-      return fail(err);
-    }
+    return handleMcpTool(request.params.name, args);
   });
 
   const transport = new StdioServerTransport();


### PR DESCRIPTION
## 改动说明

<!-- 简要描述这次 PR 干了什么、为什么 -->
1.新增 Case 能力

- OctoClient 增加 Case 的 list/create/detail/update/delete/link/unlink/note/group 等 OpenAPI 封装。
- CLI 增加 octo cases ... 一组命令。
- MCP 增加对应 octo_cases_* tools。
- README 和 octopus-openapi skill 补了 Case 文档。
- 加了 client/MCP 层测试覆盖这些映射和请求构造。

2.补齐 MCP 相对 CLI 缺失的工具
- 给 MCP 增加 Issue detail/assign/update、trace aggregate、metrics point、services entries、rum detail、users search 等工具。
- 抽出 getMcpTools / handleMcpTool，让 MCP tool list 和 handler 可以直接单测。
- 修了 metrics_point.at 的 number/string schema 与数字字符串解析问题。
- 顺带还移除了大盘 delete 暴露，文档里也从大盘 CRUD 改成只写创建/更新。

为什么做： 
让 octo-cli 的 CLI、MCP、Skill/README 三层能力对齐，尤其是让 Agent 通过 MCP 也能使用 CLI 已有的观测/协作能力；同时把高风险的大盘删除能力收掉，避免误删类操作被继续暴露。

## Checklist

- [x] 代码已通过 `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- [x] 已补齐必要的测试
- [x] 已运行 `pnpm changeset` 并提交 `.changeset/*.md`（纯文档/重构/测试可跳过）
- [x] README / CONTRIBUTING 相关文档已同步（如有必要）
