### PR TITLE
docs: 重构 README 信息架构并建立视觉系统

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ export OCTOPUS_EXTRA_HEADERS='{"X-Octopus-Tenant":"tenant-a"}'
 
 ## API 参考
 
-octo-cli 封装了 [Octopus OpenAPI](https://www.notion.so/OpenAPI-1b42090d16b681749335c62b3ed505be)，默认地址 `https://octopus-app.zhenguanyu.com`：
+octo-cli 封装了 Octopus OpenAPI，默认地址 `https://octopus-app.zhenguanyu.com`：
 
 | 领域 | 接口 |
 |------|------|

--- a/README.md
+++ b/README.md
@@ -1,96 +1,27 @@
-<div align="center">
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="100%" alt="octo-cli — 让 AI Agent 真正看懂你的系统。终端会话示例：把一个 Octopus RUM 页面 URL 贴给 Agent，Agent 转成 octo-cli 命令，统计出某接口请求 41 次、平均间隔 120ms，判定为循环请求而非重试。">
+</p>
 
-# octo-cli
+<p align="center">
+  <a href="https://www.npmjs.com/package/octo-cli"><img src="https://img.shields.io/npm/v/octo-cli.svg" alt="npm version"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="要求 Node.js 22 或更高版本">
+</p>
 
-**让 AI Agent 真正看懂你的系统 —— 不只是工具，更是上下文**
+## 一次真实排查
 
-[![npm version](https://img.shields.io/npm/v/octo-cli.svg)](https://www.npmjs.com/package/octo-cli)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+你在 Octopus RUM 页面看到某个项目的 fetch 请求异常多，把 URL 原样贴给 Agent：
 
-</div>
-
----
-
-## 为什么需要 octo-cli
-
-给 AI Agent 几个可观测工具（查日志、查指标），然后期望它能排查生产问题，就像给人一个望远镜让他在城市里找路 —— 工具能用，但不知道往哪看。
-
-可观测数据又多又杂：日志、链路、指标、告警、RUM、LLM Span、错误追踪、服务拓扑……分散在不同服务、不同环境、不同命名规则里。Agent 不知道「这个项目跑了哪些服务」「该查哪个环境」「上下游依赖是谁」，要么反复问你，要么瞎猜。
-
-**octo-cli 的解法是三层结构：**
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  上下文 (.claude/rules/octopus-observability.md)              │
-│  "这个项目跑了 service X（test 环境）和 Y（线上环境），                │
-│   X 依赖 Redis + PostgreSQL + service Z，查询要用 -e test"       │
-│  → Agent 遇到排查任务时自动加载，知道往哪看                         │
-├─────────────────────────────────────────────────────────────┤
-│  技能 (Skill)                                                │
-│  查询语法、排障流程（告警→日志→链路→拓扑）、接入引导                    │
-│  → Agent 知道怎么查，不只是知道有工具                               │
-├─────────────────────────────────────────────────────────────┤
-│  工具 (CLI + MCP)                                            │
-│  npx octo-cli logs search / trace search / metrics query ... │
-│  → Agent 有了上下文和技能，才能精准地用对工具                        │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**上下文 + 技能 + 工具**，这是「Agent 会 grep 日志」和「Agent 能排查问题」之间的差距。
-
-## 快速开始
-
-```bash
-# 一条命令完成所有准备（保存凭证 + 全局安装 Skill）
-npx octo-cli login --token <YOUR_PERSONAL_ACCESS_TOKEN>
-
-# 然后在任意项目里，对 AI Agent 说：
-#   "帮我接入 Octopus 可观测"
-#
-# Agent 会自动完成：
-#   1. 运行 npx octo-cli init（生成上下文模板 + 安装项目 Skill）
-#   2. 扫描代码（服务名、SDK、配置、环境变量）
-#   3. 查询线上 Octopus 数据（链路拓扑、入口、RUM、Issue）
-#   4. 将可观测上下文写入 .claude/rules/
-#
-# 此后，这个项目里的所有 Agent 都能精准查询 Octopus 数据。
-```
-
-## 工作原理
-
-上下文文件不是手写的 —— Agent 通过**代码分析**（SDK 导入、服务配置）和**线上链路数据**（真实拓扑、入口、依赖）自动生成。链路数据反映的是生产环境实际在跑什么，比看代码靠谱。
-
-**首次接入**一次对话完成，之后每次 Agent 会话自动加载上下文。
-
-**持续保鲜** —— 上下文不是一次性快照。项目在演进，Agent 在日常排查中如果发现数据和上下文对不上（新 service 出现、拓扑变了、接入了新 SDK、Issue 变了），会当场更新上下文文件。不需要人维护，Agent 自己保鲜。
-
-## 页面 URL 即查询入口
-
-你在 Octopus 页面上看到一个问题，想让 Agent 帮你分析 —— 不需要翻译成查询语句，直接把 URL 贴给它：
-
-```
-你：帮我看看这个页面的数据
-    https://octopus.zhenguanyu.com/#/rum-explorer?env=test&rumExplorerQuery=...&time=1d
-
-Agent：（解析 URL 参数，转成 octo-cli 命令，拿到数据，开始分析）
-```
-
-这个能力的价值在于：**你在页面上看到的和 Agent 查到的是同一份数据。** Octopus 的 URL 参数是语义化的（`env`、`query`、`time`、`application`），Agent 天然能读懂，不需要额外代码。日志页面、链路页面、RUM 页面、告警页面、大盘页面 —— 任何 Octopus URL 都能直接贴。
-
-这意味着你和 Agent 之间有了共同的「指向能力」：你指着页面说"这里有问题"，Agent 立刻能看到同一个视角的数据，然后用它擅长的方式（关联日志、追踪链路、聚合分析）去深挖。
-
-### 真实案例：从一个 URL 到定位循环请求 Bug
-
-```bash
-$ # 你在 Octopus RUM 页面看到某个项目的 fetch 请求异常多，把 URL 贴给 Agent
-
+```text
 > 帮我看看这个页面的数据
 > https://octopus.zhenguanyu.com/#/rum-explorer?env=test&rumExplorerQuery=
 > ei81ddb36uku%20AND%20resource.type%20%3D%20fetch&rumExplorerQueryEventType=
 > resource&rumExplorerSelectedApplication=rush-app&time=1d
+```
 
-$ # Agent 解析 URL，转成 octo-cli 命令
+Agent 解析 URL 参数，转成 octo-cli 命令，统计请求频次：
 
+```bash
 $ npx octo-cli rum list -e test \
     -q "application.name = rush-app AND resource.type = fetch AND ei81ddb36uku" \
     -l 1d -n 500 -o json \
@@ -103,9 +34,11 @@ $ npx octo-cli rum list -e test \
       4 "GET /api/projects"
       3 "GET /api/version/list"
 #    ^^^ 三个接口 40 次 vs 正常请求 3-8 次，明显异常
+```
 
-$ # Agent 继续深挖：这些请求的时间分布
+接着自己深挖时间分布，确认是循环而不是重试：
 
+```bash
 $ npx octo-cli rum list -e test \
     -q "application.name = rush-app AND resource.type = fetch AND ei81ddb36uku" \
     -l 1d -n 500 -o json \
@@ -119,75 +52,72 @@ $ # useChat resume → 流结束 → onFinish → generateTitle + 刷新状态 �
 $ # 根因：resume 机制 + onFinish 回调 + 状态刷新形成无限循环
 ```
 
-**从贴 URL 到定位根因，一次对话。** 你在页面上看到"这个项目请求数量不对"，Agent 用同一份数据确认了你的直觉，然后做了你不想手动做的事：统计频次、分析时间分布、追到代码里找出循环。
+**从贴 URL 到定位根因，一次对话。** 你在页面上看到「这个项目请求数量不对」，Agent 用同一份数据确认了你的直觉，然后做了你不想手动做的事：统计频次、分析时间分布、追到代码里找出循环。
 
-## 功能特性
+## 为什么不是「给 Agent 几个查询工具」就够了
 
-- **Agent 原生接入** —— `login` 全局装 Skill，`init` 生成项目上下文，Agent 自己填写
-- **全量 Octopus OpenAPI 覆盖** —— 日志、告警、Issue、Case、链路、指标、服务、LLM、RUM、事件、大盘
-- **人性化时间范围** —— `--last 15m`、`--last 2h`、`--last 7d`
-- **多种输出格式** —— `--output json`、`--output table`、`--output jsonl`
-- **MCP Server** —— 内置 stdio MCP Server，支持 Claude Code、Cursor 等
-- **安全鉴权** —— 支持 Personal Access Token（推荐）和 Application Key 两种认证方式
-- **配套 Skill** —— 7 个深度 Skill，覆盖查询语法、指标 QL、RUM、LLM 追踪、数据采集
+给 AI Agent 几个可观测工具（查日志、查指标），然后期望它能排查生产问题，就像给人一个望远镜让他在城市里找路 —— 工具能用，但不知道往哪看。
 
-## 安装
+可观测数据又多又杂：日志、链路、指标、告警、RUM、LLM Span、错误追踪、服务拓扑……分散在不同服务、不同环境、不同命名规则里。Agent 不知道「这个项目跑了哪些服务」「该查哪个环境」「上下游依赖是谁」，要么反复问你，要么瞎猜。
 
-**要求：** Node.js >= 22.0.0
+octo-cli 的解法是三层结构：**上下文**（这个项目跑了什么、依赖谁、该查哪个环境）→ **技能**（查询语法、排障流程）→ **工具**（CLI 命令与 38 个 MCP 工具）。三层齐了，才是「Agent 会 grep 日志」和「Agent 能排查问题」之间的差距。
 
-```bash
-npx octo-cli <command>          # 通过 npx 直接使用
-npm install -g octo-cli         # 或全局安装，使用 octo 简写
-```
+<p align="center">
+  <img src="./assets/readme/architecture.svg" width="100%" alt="octo-cli 的三层结构。第一层上下文：记录项目跑了哪些服务、依赖什么、该查哪个环境，由 Agent 自动生成并保鲜，0 人工维护。第二层技能：7 个领域 Skill 提供查询语法和排障流程，让 Agent 知道怎么查。第三层工具：CLI 命令与 38 个 MCP 工具，Agent 有了前两层才能精准用对工具。">
+</p>
 
-## 认证
+上下文文件不是手写的 —— Agent 通过**代码分析**（SDK 导入、服务配置）和**线上链路数据**（真实拓扑、入口、依赖）自动生成。链路数据反映的是生产环境实际在跑什么，比看代码靠谱。
 
-### Personal Access Token（推荐）
+**持续保鲜** —— 上下文不是一次性快照。项目在演进，Agent 在日常排查中如果发现数据和上下文对不上（新 service 出现、拓扑变了、接入了新 SDK、Issue 变了），会当场更新上下文文件。不需要人维护，Agent 自己保鲜。
 
-1. 在 Octopus Web 页面左下角用户菜单中，点击「Access Token」
-2. 创建一个 Token，复制生成的 `oct_pat_xxx` 值
+## 快速开始
 
 ```bash
-# 登录（同时全局安装 Skill）
-octo-cli login --token <YOUR_PERSONAL_ACCESS_TOKEN>
-
-# 或通过环境变量
-export OCTOPUS_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN>
-
-# 可选：为所有 OpenAPI 请求附加自定义 Header（JSON 对象）
-export OCTOPUS_EXTRA_HEADERS='{"X-Octopus-Tenant":"tenant-a"}'
+# 一条命令完成所有准备（保存凭证 + 全局安装 Skill）
+npx octo-cli login --token <YOUR_PERSONAL_ACCESS_TOKEN>
 ```
 
-### Application Key（已废弃，下个版本将移除）
+> Token 获取方式：Octopus Web 页面左下角用户菜单 →「Access Token」→ 创建，复制 `oct_pat_xxx`。
 
-> **Deprecation Notice：** Application Key 认证方式将在下一个版本中移除，请尽快迁移到 Personal Access Token。
+然后在任意项目里，对 AI Agent 说 **「帮我接入 Octopus 可观测」**，Agent 会自动完成：
 
-```bash
-octo-cli login --app-id <APP_ID> --app-secret <APP_SECRET>
+1. 运行 `npx octo-cli init`（生成上下文模板 + 安装项目 Skill）
+2. 扫描代码（服务名、SDK、配置、环境变量）
+3. 查询线上 Octopus 数据（链路拓扑、入口、RUM、Issue）
+4. 把可观测上下文写入 `.claude/rules/octopus-observability.md`
 
-# 或通过环境变量
-export OCTOPUS_APP_ID=<APP_ID>
-export OCTOPUS_APP_SECRET=<APP_SECRET>
-```
+此后这个项目里的所有 Agent 会话都会自动加载该上下文。生成的文件会告诉 Agent：项目部署了哪些服务、分别在什么环境、接入了哪些数据采集、服务拓扑和上下游依赖、用实际服务名填好的查询命令、已知问题和监控查询。
 
-## 项目接入
+## 页面 URL 即查询入口
 
-```bash
-# 在项目目录下执行：
-octo-cli init
-# → 生成 .claude/rules/octopus-observability.md（带 AGENT 指令的模板）
-# → 安装项目级 Skill
-# → Agent 读取模板 → 扫描代码 → 查询 Octopus → 填写上下文
-```
+你在 Octopus 页面上看到一个问题，想让 Agent 帮你分析 —— 不需要翻译成查询语句，直接把 URL 贴给它（[上面的排查案例](#一次真实排查)就是这么开始的）。
 
-生成的上下文文件会告诉 Agent：
-- 这个项目部署了哪些服务，分别在什么环境
-- 接入了哪些数据采集（日志、链路、指标、RUM、LLM）
-- 用实际服务名填好的查询命令
-- 服务拓扑和上下游依赖（来自线上链路数据）
-- 已知问题和监控查询
+Octopus 的 URL 参数是语义化的（`env`、`query`、`time`、`application`），Agent 天然能读懂，不需要额外代码。日志页面、链路页面、RUM 页面、告警页面、大盘页面 —— 任何 Octopus URL 都能直接贴。
+
+这个能力的价值在于：**你在页面上看到的和 Agent 查到的是同一份数据。** 你和 Agent 之间有了共同的「指向能力」—— 你指着页面说「这里有问题」，Agent 立刻能看到同一个视角的数据，然后用它擅长的方式（关联日志、追踪链路、聚合分析）去深挖。
 
 ## 命令
+
+所有查询命令共享这些选项：
+
+| 选项 | 说明 | 示例 |
+|------|------|------|
+| `-l, --last <duration>` | 相对时间范围 | `15m`、`1h`、`2d`、`1w` |
+| `--from` / `--to <time>` | 绝对时间 | 毫秒时间戳或 ISO 字符串 |
+| `-e, --env <env>` | 环境 | `online`、`test` |
+| `-q, --query <query>` | 查询语句 | `level = ERROR` |
+| `-o, --output <fmt>` | 输出格式 | `json`、`table`、`jsonl` |
+| `-n, --limit <n>` | 最大返回条数 | `50` |
+
+```bash
+octo-cli logs search -q "level = ERROR" -l 15m       # 搜索日志
+octo-cli alerts search -s firing -p P0,P1 -l 1h      # 正在触发的 P0/P1 告警
+octo-cli trace aggregate -a "duration:p95" -g service # 按服务聚合 P95 延迟
+octo-cli services topo myapp                          # 服务拓扑图
+```
+
+<details>
+<summary><b>按领域展开全部命令</b></summary>
 
 ### 日志
 
@@ -250,110 +180,75 @@ octo-cli cases link <caseId> --type alert --target-id 123 # 关联告警
 octo-cli cases note <caseId> --text "已通知负责人"          # 添加备注
 ```
 
-### 链路 (Trace)
+### 链路 (Trace) / 指标 (Metrics)
 
 ```bash
 octo-cli trace search -q "service = myapp" -l 15m        # 搜索 Span
 octo-cli trace aggregate -a "duration:p95" -g service     # 按服务聚合 P95 延迟
-```
 
-### 指标 (Metrics)
-
-```bash
 octo-cli metrics query "sum(http_requests{}.as_count)" -l 1h       # 时序查询
 octo-cli metrics query "avg(cpu_usage{service=myapp})" --points 50  # 指定数据点数
 octo-cli metrics point "sum(error_count{}.as_count)"                 # 单点查询
 ```
 
-### 服务 / APM
+### 服务 / LLM / RUM / 事件 / 用户
 
 ```bash
 octo-cli services list -l 1h                              # 列出活跃服务
 octo-cli services entries myapp -l 1h                     # 服务入口列表
 octo-cli services topo myapp                              # 服务拓扑图
-```
 
-### LLM / RUM / 事件
-
-```bash
 octo-cli llm -l 1h -q "model.name = gpt-4"              # LLM 可观测
 octo-cli rum list -e test -q "application.name = myapp" -l 1d   # RUM 会话
 octo-cli rum detail <id>                                  # RUM 事件详情
 octo-cli events -l 1d                                     # 部署事件
-```
-
-### 用户
-
-```bash
 octo-cli users alice bob                                  # 按姓名搜索用户
 ```
 
-## 命令速查
+</details>
+
+<details>
+<summary><b>命令速查表</b></summary>
 
 | 命令 | 说明 |
 |------|------|
 | `login` | 配置凭证 + 全局安装 Skill |
 | `init` | 项目接入：生成上下文模板 + 安装 Skill |
-| `logs search` | 搜索日志 |
-| `logs aggregate` | 日志聚合 |
-| `alerts search` | 搜索告警 |
-| `alerts rules` | 搜索告警规则 |
-| `alerts create` | 从 JSON 创建告警规则 |
-| `alerts delete` | 删除告警规则 |
-| `alerts silence` | 创建告警静默 |
-| `alerts unsilence` | 解除告警静默 |
-| `issues search` | 搜索错误追踪 Issue |
-| `issues detail` | Issue 详情 |
-| `issues assign` | 批量分配 Issue |
-| `issues update` | 批量更新 Issue 状态 |
-| `cases list` | 查询 Case |
-| `cases create` | 创建 Case |
+| `logs search` / `logs aggregate` | 搜索日志 / 日志聚合 |
+| `alerts search` / `alerts rules` | 搜索告警 / 搜索告警规则 |
+| `alerts create` / `alerts delete` | 从 JSON 创建 / 删除告警规则 |
+| `alerts silence` / `alerts unsilence` | 创建 / 解除告警静默 |
+| `issues search` / `issues detail` | 搜索 Issue / Issue 详情 |
+| `issues assign` / `issues update` | 批量分配 / 批量更新 Issue 状态 |
+| `cases list` / `cases create` | 查询 / 创建 Case |
 | `cases detail` / `cases detail-key` | Case 详情 |
 | `cases update` / `cases delete` | 更新或删除 Case |
 | `cases link` / `cases unlink` | 关联或取消关联告警/Issue |
 | `cases note` / `cases note-update` | 添加或修改 Case 备注 |
 | `cases groups` / `cases group-create` | 查询或创建 Case 分组 |
-| `trace search` | 搜索链路 Span |
-| `trace aggregate` | 链路聚合 |
-| `metrics query` | 指标时序查询 |
-| `metrics point` | 指标单点查询 |
-| `services list` | 服务列表 |
-| `services entries` | 服务入口列表 |
-| `services topo` | 服务拓扑图 |
+| `trace search` / `trace aggregate` | 搜索链路 Span / 链路聚合 |
+| `metrics query` / `metrics point` | 指标时序查询 / 单点查询 |
+| `services list` / `services entries` / `services topo` | 服务列表 / 入口列表 / 拓扑图 |
 | `llm` | LLM Span 查询 |
-| `rum list` | RUM 事件列表 |
-| `rum detail` | RUM 事件详情 |
+| `rum list` / `rum detail` | RUM 事件列表 / 详情 |
 | `events` | 事件查询 |
 | `users` | 用户搜索 |
-| `mcp` | 启动 MCP Server |
-| `mcp-install` | 一键注册 MCP Server 到 Claude Code |
+| `mcp` / `mcp-install` | 启动 MCP Server / 一键注册到 Claude Code |
 
-## 通用选项
+</details>
 
-所有查询命令支持：
+## Unix 管道
 
-| 选项 | 说明 | 示例 |
-|------|------|------|
-| `-l, --last <duration>` | 相对时间范围 | `15m`、`1h`、`2d`、`1w` |
-| `--from <time>` | 绝对起始时间 | 毫秒时间戳或 ISO 字符串 |
-| `--to <time>` | 绝对结束时间 | 毫秒时间戳或 ISO 字符串 |
-| `-e, --env <env>` | 环境 | `online`、`test` |
-| `-q, --query <query>` | 查询语句 | `level = ERROR` |
-| `-o, --output <fmt>` | 输出格式 | `json`、`table`、`jsonl` |
-| `-n, --limit <n>` | 最大返回条数 | `50` |
-
-## Unix 管道 —— 可观测数据的组合拳
-
-所有命令输出到 stdout，支持 `json` 和 `jsonl` 两种格式，天然适配 `jq`、`grep`、`sort`、`awk` 等 Unix 工具。这不是附加功能，而是核心设计 —— 可观测数据的价值在于**组合和关联**，而不是一条条孤立地看。
+所有命令输出到 stdout，支持 `json` 和 `jsonl` 两种格式，天然适配 `jq`、`grep`、`sort`、`awk`。这不是附加功能，而是核心设计 —— 可观测数据的价值在于**组合和关联**，而不是一条条孤立地看。
 
 ```bash
-# 告警 → 提取 service tag → 去重
-octo-cli alerts search -s firing -l 1h -o json | jq -r '.[].tags[]?' | grep 'service:' | sort -u
-
 # 按 ERROR 数量排序找出最严重的服务
 octo-cli logs aggregate -q "level = ERROR" -g service:10 -l 1h -o json \
   | jq -r '.[] | select(.fields.service) | "\(.values["count(*)"]) \(.fields.service)"' \
   | sort -rn
+
+# 告警 → 提取 service tag → 去重
+octo-cli alerts search -s firing -l 1h -o json | jq -r '.[].tags[]?' | grep 'service:' | sort -u
 
 # 逐条告警带优先级格式化
 octo-cli alerts search -s firing -l 1h -o jsonl | jq -r '"[\(.priority)] \(.title)"'
@@ -367,20 +262,18 @@ octo-cli trace search -q "service = myapp AND operation = http.server" -l 1h -n 
   | jq -r '.spanItems[] | "\(.duration)ms \(.name)"' | sort -rn | head -10
 ```
 
-Agent 也是这么用的 —— 它会把 octo-cli 的输出 pipe 到 jq 做二次提取，pipe 到 sort 做排序，pipe 到 grep 做过滤。CLI 输出越干净，Agent 的组合能力越强。
+Agent 也是这么用的 —— 把输出 pipe 到 `jq` 做二次提取、pipe 到 `sort` 排序、pipe 到 `grep` 过滤。CLI 输出越干净，Agent 的组合能力越强。
 
 ## MCP Server
 
-内置 MCP Server，支持 Claude Code、Cursor 等 AI Agent 直接调用。
-
-### 一键安装
+内置 stdio MCP Server，38 个工具，支持 Claude Code、Cursor 等 AI Agent 直接调用。
 
 ```bash
 # 前提：已执行 octo-cli login
 npx octo-cli mcp-install
 ```
 
-自动读取已保存的凭证，注册到 Claude Code。也可以手动配置：
+自动读取已保存的凭证并注册到 Claude Code。也可以手动配置：
 
 ```json
 {
@@ -396,41 +289,33 @@ npx octo-cli mcp-install
 }
 ```
 
-### MCP 工具列表
+<details>
+<summary><b>MCP 工具列表</b></summary>
 
 | 工具 | 说明 |
 |------|------|
-| `octo_logs_search` | 搜索日志 |
-| `octo_logs_aggregate` | 日志聚合 |
+| `octo_logs_search` / `octo_logs_aggregate` | 搜索日志 / 日志聚合 |
 | `octo_alerts_search` | 搜索告警 |
 | `octo_alerts_rules_search` | 搜索告警规则 |
-| `octo_alerts_rules_create` | 创建告警规则 |
-| `octo_alerts_rules_delete` | 删除告警规则 |
-| `octo_alerts_silence_create` | 创建告警静默 |
-| `octo_alerts_silence_delete` | 解除告警静默 |
-| `octo_issues_search` | 搜索错误追踪 Issue |
-| `octo_issues_detail` | Issue 详情 |
-| `octo_issues_assign` | 批量分配 Issue |
-| `octo_issues_update` | 批量更新 Issue 状态 |
-| `octo_cases_list` | 查询 Case |
-| `octo_cases_create` | 创建 Case |
+| `octo_alerts_rules_create` / `octo_alerts_rules_delete` | 创建 / 删除告警规则 |
+| `octo_alerts_silence_create` / `octo_alerts_silence_delete` | 创建 / 解除告警静默 |
+| `octo_issues_search` / `octo_issues_detail` | 搜索 Issue / Issue 详情 |
+| `octo_issues_assign` / `octo_issues_update` | 批量分配 / 批量更新 Issue |
+| `octo_cases_list` / `octo_cases_create` | 查询 / 创建 Case |
 | `octo_cases_detail` / `octo_cases_detail_by_key` | Case 详情 |
 | `octo_cases_update` / `octo_cases_delete` | 更新或删除 Case |
 | `octo_cases_link` / `octo_cases_unlink` | 关联或取消关联告警/Issue |
 | `octo_cases_note_add` / `octo_cases_note_update` | 添加或修改 Case 备注 |
 | `octo_cases_groups_all` / `octo_cases_group_create` | 查询或创建 Case 分组 |
-| `octo_trace_search` | 搜索链路 Span |
-| `octo_trace_aggregate` | 链路聚合 |
-| `octo_metrics_query` | 指标时序查询 |
-| `octo_metrics_point` | 指标单点查询 |
-| `octo_services_list` | 服务列表 |
-| `octo_services_entries` | 服务入口列表 |
-| `octo_services_topology` | 服务拓扑图 |
+| `octo_trace_search` / `octo_trace_aggregate` | 搜索链路 Span / 链路聚合 |
+| `octo_metrics_query` / `octo_metrics_point` | 指标时序 / 单点查询 |
+| `octo_services_list` / `octo_services_entries` / `octo_services_topology` | 服务列表 / 入口 / 拓扑 |
 | `octo_llm_list` | LLM Span 查询 |
-| `octo_rum_list` | RUM 事件查询 |
-| `octo_rum_detail` | RUM 事件详情 |
+| `octo_rum_list` / `octo_rum_detail` | RUM 事件查询 / 详情 |
 | `octo_events_list` | 事件查询 |
 | `octo_users_search` | 用户搜索 |
+
+</details>
 
 ## 配套 Skill
 
@@ -450,9 +335,32 @@ npx reskill install github:kanyun-inc/octo-cli/skills/octopus-log-query -a claud
 | `octopus-openapi` | OpenAPI 签名（V1/V2）、SDK 集成、全量 HTTP 接口 |
 | `octopus-web-sdk-helper` | Web SDK 排障、配置指导、Source Map 上传 |
 
+## 安装与认证
+
+**要求：** Node.js >= 22.0.0
+
+```bash
+npx octo-cli <command>          # 通过 npx 直接使用
+npm install -g octo-cli         # 或全局安装，使用 octo 简写
+```
+
+推荐用 Personal Access Token 认证：
+
+```bash
+octo-cli login --token <YOUR_PERSONAL_ACCESS_TOKEN>
+
+# 或通过环境变量
+export OCTOPUS_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN>
+
+# 可选：为所有 OpenAPI 请求附加自定义 Header（JSON 对象）
+export OCTOPUS_EXTRA_HEADERS='{"X-Octopus-Tenant":"tenant-a"}'
+```
+
+> **Deprecation Notice：** Application Key 认证（`--app-id` / `--app-secret`，环境变量 `OCTOPUS_APP_ID` / `OCTOPUS_APP_SECRET`）将在下一个版本中移除，请尽快迁移到 Personal Access Token。
+
 ## API 参考
 
-octo-cli 封装了 [Octopus OpenAPI](https://www.notion.so/OpenAPI-1b42090d16b681749335c62b3ed505be)：
+octo-cli 封装了 [Octopus OpenAPI](https://www.notion.so/OpenAPI-1b42090d16b681749335c62b3ed505be)，默认地址 `https://octopus-app.zhenguanyu.com`：
 
 | 领域 | 接口 |
 |------|------|
@@ -468,8 +376,6 @@ octo-cli 封装了 [Octopus OpenAPI](https://www.notion.so/OpenAPI-1b42090d16b68
 | 事件 | `/v1/event/list` |
 | 大盘 | `/v1/dashboards`（创建 / 更新） |
 | 用户 | `/v1/users/search` |
-
-鉴权：支持 Personal Access Token（Bearer Token）和 Application Key（OC-HMAC-SHA256-2 签名）。默认地址：`https://octopus-app.zhenguanyu.com`。
 
 ## 贡献
 

--- a/assets/readme/architecture.svg
+++ b/assets/readme/architecture.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 548" width="1200" height="548" role="img" aria-labelledby="archTitle archDesc">
+  <title id="archTitle">octo-cli 的三层结构：上下文、技能、工具</title>
+  <desc id="archDesc">第一层上下文记录项目跑了哪些服务、依赖什么、该查哪个环境，由 Agent 自动生成并保鲜，无需人工维护。第二层是 7 个领域技能，提供查询语法和排障流程，让 Agent 知道怎么查。第三层是 CLI 命令与 38 个 MCP 工具，Agent 有了前两层才能精准用对工具。</desc>
+
+  <defs>
+    <style>
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", sans-serif; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="548" fill="#0d1117"/>
+
+  <!-- ============ layer 1: context ============ -->
+  <g>
+    <rect x="56" y="28" width="1088" height="148" rx="12" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+    <rect x="56" y="28" width="5" height="148" rx="2.5" fill="#58a6ff"/>
+
+    <text class="mono" x="88" y="70" font-size="40" font-weight="700" fill="#58a6ff" opacity="0.32">01</text>
+    <text class="sans" x="88" y="112" font-size="30" font-weight="600" fill="#e6edf3">上下文</text>
+    <text class="mono" x="88" y="142" font-size="18" fill="#6e7681">.claude/rules/</text>
+
+    <line x1="268" y1="52" x2="268" y2="152" stroke="#21262d" stroke-width="1"/>
+
+    <text class="mono" x="300" y="72" font-size="20" fill="#c9d1d9">service X（test）· service Y（online）</text>
+    <text class="mono" x="300" y="102" font-size="20" fill="#8b949e">依赖 Redis · PostgreSQL · service Z，查询用 -e test</text>
+    <text class="sans" x="300" y="140" font-size="20" fill="#58a6ff">→ 排查时自动加载，Agent 知道<tspan font-weight="600">往哪看</tspan></text>
+
+    <line x1="936" y1="52" x2="936" y2="152" stroke="#21262d" stroke-width="1"/>
+    <text class="mono" x="1112" y="102" font-size="52" font-weight="700" fill="#58a6ff" text-anchor="end">0</text>
+    <text class="sans" x="1112" y="130" font-size="18" fill="#6e7681" text-anchor="end">人工维护</text>
+  </g>
+
+  <path d="M600 176 L600 190" stroke="#30363d" stroke-width="2"/>
+  <path d="M594 186 L600 194 L606 186" fill="none" stroke="#30363d" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- ============ layer 2: skills ============ -->
+  <g>
+    <rect x="56" y="200" width="1088" height="148" rx="12" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+    <rect x="56" y="200" width="5" height="148" rx="2.5" fill="#a371f7"/>
+
+    <text class="mono" x="88" y="242" font-size="40" font-weight="700" fill="#a371f7" opacity="0.32">02</text>
+    <text class="sans" x="88" y="284" font-size="30" font-weight="600" fill="#e6edf3">技能</text>
+    <text class="mono" x="88" y="314" font-size="18" fill="#6e7681">Skill</text>
+
+    <line x1="268" y1="224" x2="268" y2="324" stroke="#21262d" stroke-width="1"/>
+
+    <text class="mono" x="300" y="244" font-size="20" fill="#c9d1d9">查询语法 · 指标 QL · RUM · LLM 追踪 · 数据采集</text>
+    <text class="mono" x="300" y="274" font-size="20" fill="#8b949e">排障流程：告警 → 日志 → 链路 → 拓扑</text>
+    <text class="sans" x="300" y="312" font-size="20" fill="#a371f7">→ 不只知道有工具，还知道<tspan font-weight="600">怎么查</tspan></text>
+
+    <line x1="936" y1="224" x2="936" y2="324" stroke="#21262d" stroke-width="1"/>
+    <text class="mono" x="1112" y="274" font-size="52" font-weight="700" fill="#a371f7" text-anchor="end">7</text>
+    <text class="sans" x="1112" y="302" font-size="18" fill="#6e7681" text-anchor="end">个领域 Skill</text>
+  </g>
+
+  <path d="M600 348 L600 362" stroke="#30363d" stroke-width="2"/>
+  <path d="M594 358 L600 366 L606 358" fill="none" stroke="#30363d" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- ============ layer 3: tools ============ -->
+  <g>
+    <rect x="56" y="372" width="1088" height="148" rx="12" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+    <rect x="56" y="372" width="5" height="148" rx="2.5" fill="#3fb950"/>
+
+    <text class="mono" x="88" y="414" font-size="40" font-weight="700" fill="#3fb950" opacity="0.32">03</text>
+    <text class="sans" x="88" y="456" font-size="30" font-weight="600" fill="#e6edf3">工具</text>
+    <text class="mono" x="88" y="486" font-size="18" fill="#6e7681">CLI + MCP</text>
+
+    <line x1="268" y1="396" x2="268" y2="496" stroke="#21262d" stroke-width="1"/>
+
+    <text class="mono" x="300" y="416" font-size="20">
+      <tspan fill="#3fb950">$</tspan><tspan fill="#c9d1d9" dx="8">octo-cli logs search / trace search / metrics …</tspan>
+    </text>
+    <text class="mono" x="300" y="446" font-size="20" fill="#8b949e">CLI 与 MCP 共用同一套查询能力</text>
+    <text class="sans" x="300" y="484" font-size="20" fill="#3fb950">→ 有了上下文和技能，才能<tspan font-weight="600">精准用对工具</tspan></text>
+
+    <line x1="936" y1="396" x2="936" y2="496" stroke="#21262d" stroke-width="1"/>
+    <text class="mono" x="1112" y="446" font-size="52" font-weight="700" fill="#3fb950" text-anchor="end">38</text>
+    <text class="sans" x="1112" y="474" font-size="18" fill="#6e7681" text-anchor="end">个 MCP 工具</text>
+  </g>
+
+</svg>

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" width="1200" height="420" role="img" aria-labelledby="heroTitle heroDesc">
+  <title id="heroTitle">octo-cli — 让 AI Agent 真正看懂你的系统</title>
+  <desc id="heroDesc">终端会话示例：把一个 Octopus RUM 页面 URL 贴给 Agent，Agent 转成 octo-cli 命令，统计出某接口 1 天内请求 41 次、平均间隔 120ms，判定为循环请求而非重试。</desc>
+
+  <defs>
+    <style>
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", sans-serif; }
+    </style>
+    <clipPath id="termBarClip">
+      <rect x="56" y="232" width="1088" height="134" rx="10"/>
+    </clipPath>
+  </defs>
+
+  <rect width="1200" height="420" fill="#0d1117"/>
+
+  <!-- eyebrow -->
+  <text class="mono" x="56" y="72" fill="#8b949e" font-size="19" letter-spacing="2.4">OBSERVABILITY CLI · MCP SERVER · AGENT SKILLS</text>
+
+  <!-- wordmark: the prompt is part of the name, cursor sits after it -->
+  <text class="mono" x="56" y="148" font-size="72" font-weight="700" fill="#3fb950">$</text>
+  <text class="mono" x="106" y="148" font-size="72" font-weight="700" fill="#e6edf3">octo-cli</text>
+  <rect x="466" y="110" width="20" height="46" fill="#3fb950" opacity="0.9"/>
+
+  <!-- tagline -->
+  <text class="sans" x="58" y="192" font-size="26" fill="#c9d1d9">让 AI Agent 真正看懂你的系统 —— 不只是给工具，更是给上下文</text>
+
+  <line x1="56" y1="214" x2="1144" y2="214" stroke="#21262d" stroke-width="1"/>
+
+  <!-- terminal window: one real investigation, three lines -->
+  <g>
+    <rect x="56" y="232" width="1088" height="134" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+    <g clip-path="url(#termBarClip)">
+      <rect x="56" y="232" width="1088" height="34" fill="#1c2128"/>
+    </g>
+    <line x1="56" y1="266" x2="1144" y2="266" stroke="#30363d" stroke-width="1.5"/>
+    <circle cx="80" cy="249" r="5.5" fill="#3d444d"/>
+    <circle cx="99" cy="249" r="5.5" fill="#3d444d"/>
+    <circle cx="118" cy="249" r="5.5" fill="#3d444d"/>
+    <text class="mono" x="140" y="255" font-size="18" fill="#6e7681">一次真实排查</text>
+
+    <text class="mono" x="80" y="296" font-size="19">
+      <tspan fill="#3fb950">$</tspan><tspan fill="#c9d1d9" dx="10">帮我看看这个页面 </tspan><tspan fill="#58a6ff">/rum-explorer?env=test&amp;application=rush-app</tspan>
+    </text>
+
+    <text class="mono" x="80" y="322" font-size="19">
+      <tspan fill="#6e7681">→</tspan><tspan fill="#8b949e" dx="10">octo-cli rum list -e test -q "resource.type = fetch" -o json | jq … | uniq -c</tspan>
+    </text>
+
+    <text class="mono" x="80" y="348" font-size="19">
+      <tspan fill="#6e7681">→</tspan><tspan fill="#d29922" dx="10" font-weight="600">41 次</tspan><tspan fill="#c9d1d9" dx="6">ai-stream-v2，平均间隔 </tspan><tspan fill="#d29922" font-weight="600">120ms</tspan><tspan fill="#c9d1d9" dx="6">—— 这是循环，不是重试</tspan>
+    </text>
+  </g>
+
+  <text class="mono" x="56" y="398" font-size="18" fill="#6e7681">Claude Code · Cursor · Codex　|　内置 MCP Server　|　Node ≥ 22　|　MIT</text>
+</svg>

--- a/skills/octopus-openapi/SKILL.md
+++ b/skills/octopus-openapi/SKILL.md
@@ -10,11 +10,11 @@ tags:
   - observability
 ---
 
-<!-- source: Notion「Octopus 用户文档 → OpenAPI」及子页面，synced 2026-03-25 -->
+<!-- source: Octopus 官方 OpenAPI 文档，synced 2026-03-25 -->
 
 # Octopus OpenAPI 接口指南
 
-## 文档结构（与 Notion 目录一致）
+## 文档结构（与官方文档目录一致）
 
 | 主题 | 说明 |
 |------|------|
@@ -507,7 +507,7 @@ Case 返回结构与 `infra-octopus-rest` 的 Case API 保持一致；OpenAPI �
 
 ### 8.3 创建告警规则 `POST /infra-octopus-openapi/v1/alert/rules`
 
-Body 为规则 **数组**；字段含 `name`、`env`、`priority`、`ruleType`（log/metric/issue）、`conditions`、`conditionEvaluationType`（single/and/or）、`notice`、`groupId`、`tags`、`active` 等（结构复杂，以 Notion 长 JSON 为准）。
+Body 为规则 **数组**；字段含 `name`、`env`、`priority`、`ruleType`（log/metric/issue）、`conditions`、`conditionEvaluationType`（single/and/or）、`notice`、`groupId`、`tags`、`active` 等（结构复杂，以官方文档中的完整 JSON 为准）。
 
 ### 8.4 删除告警规则 `DELETE /infra-octopus-openapi/v1/alert/rules`
 
@@ -557,7 +557,7 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 
 ## 十、大盘相关接口
 
-- **创建** `POST /infra-octopus-openapi/v1/dashboards`：Body 含 `parent`（**目录 id，必填**）、`title`、`variableList`、`widgetList` 等；结构复杂，建议从页面已有大盘导出 JSON 再改。可参考浏览器控制台拉取 `infra-octopus-rest` 下大盘详情接口中的 `data` 字段（见 Notion 原文）。
+- **创建** `POST /infra-octopus-openapi/v1/dashboards`：Body 含 `parent`（**目录 id，必填**）、`title`、`variableList`、`widgetList` 等；结构复杂，建议从页面已有大盘导出 JSON 再改。可参考浏览器控制台拉取 `infra-octopus-rest` 下大盘详情接口中的 `data` 字段（见官方文档）。
 - **更新** `PUT /infra-octopus-openapi/v1/dashboards/{id}`：**全量覆盖**。
 
 业务与数据结构可能迭代，以最新文档为准。


### PR DESCRIPTION
参照 [beautify-github-readme](https://github.com/oil-oil/beautify-github-readme) 的方法论重做 README：把最强的证明提到第一屏，并用项目自身的素材建立视觉层。

## 改了什么

**证明前置。** 原 README 最有说服力的内容是「从一个 URL 到定位循环请求 Bug」的真实案例——有真实命令、真实输出、真实结论（41 次 vs 正常 3-8 次，间隔 120ms 判定为循环而非重试）。它原本在第 82 行，访客要滚过两屏论述才看得到。现在它是正文第一节。

**建立视觉层。** 原 README 484 行、42 个代码块、**0 张图**，连 assets 目录都没有。新增两张 SVG：

| 资源 | 作用 |
|------|------|
| `hero.svg` | 项目名与一次真实终端会话共享同一网格，第一眼就能看到「贴 URL → 转成命令 → 得出结论」的完整链条 |
| `architecture.svg` | 三层结构图，替代原来的 ASCII 框线图（窄屏会错位、视觉权重弱） |

视觉语言取自项目本身而非通用模板：CLI 工具用终端配色、等宽字体，提示符 `$` 与光标块作为贯穿两图的 motif。

**去重与压缩，484 → 390 行：**

- 「功能特性」7 条 bullet 与 MCP / Skill / 输出格式等章节重复，并入各章节
- 「命令」的分领域示例（~100 行）与「命令速查」表格（~40 行）是同一份信息的两种列法，改为默认收起的 `<details>`
- 「安装」与「认证」合并；「工作原理」并入机制章节

## 数字都与代码核对过

架构图里的量化不是估的：

- **38 个 MCP 工具** — `grep -c "name: 'octo_" src/mcp.ts` = 38（README 原表格看起来是 31，因为有合并行）
- **7 个领域 Skill** — `ls -d skills/octopus-*/` = 7
- **0 人工维护** — 对应上下文由 Agent 自动生成并保鲜的既有描述

## 验证

- 用 GitHub 自己的 `/markdown` API 渲染后在浏览器检查，896px 与 360px 两种宽度
- 页面无横向滚动；代码块在各自容器内滚动（GitHub 的正常行为）
- 两张 SVG 的文本用 `getBBox()` 逐个测量，无溢出、无跨列重叠；所有必需文字在 900px 渲染宽度下 ≥ 18 SVG units
- 跑了该 skill 自带的 `audit_readme.py`，通过

顺带修了一个健壮性问题：badge 的 alt 文本里含 `>` 字符，会让 `<img[^>]*>` 这类简单正则提前截断标签（浏览器解析没问题，但部分 Markdown 处理器会出错）。

## 兼容性

两张 SVG 自带背景，适配 GitHub 明暗主题；含 `title` 与 `desc`；未使用 script、foreignObject、外部字体或动画等 GitHub 会剥离的特性；合计 12 KB。命令、链接、表格全部留在 Markdown 里，保持可复制可搜索。`package.json` 的 `files` 只含 `dist`，新增的 `assets/` 不会进 npm 包。

## 移除内部文档地址

公开仓库不再暴露内部文档来源（第二个 commit）：

- README 的 API 参考去掉了指向 Notion 的 OpenAPI 文档链接。默认 API 地址 `https://octopus-app.zhenguanyu.com` 保留 —— 那是 CLI 在 `src/config.ts` 里的实际默认配置，不是文档地址。
- `skills/octopus-openapi/SKILL.md` 的来源标注、目录说明，以及两处「以 Notion 原文为准」改为中性的「官方文档」表述，信息完整性不变。

已全仓库 grep 复查（md / ts / json / yml），工作树无 Notion 残留。本 PR 之前的描述里同一处链接也已移除。

> 注意：`git log` 中的历史提交（最早可追到 `5858fff`）仍含该链接。已推送的公开历史没有擅自改写，如需彻底清除要单独走 history rewrite。

## 未改动

源码、测试、skills 目录、CONTRIBUTING.md、CLAUDE.md 均未触碰。纯文档变更，按项目约定不需要 changeset。

> 与 #27 的关系：两者都改 README，合并时需要手工解冲突。本 PR 基于 main，因此告警章节不含 #27 新增的 `alerts disable/disables/enable`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
