### PR TITLE
feat(alert): 支持告警组和规则详情查询

### DIFF
--- a/.changeset/alert-rule-query-apis.md
+++ b/.changeset/alert-rule-query-apis.md
@@ -1,0 +1,8 @@
+---
+'octo-cli': minor
+---
+
+新增告警组列表和告警规则批量详情查询能力。
+
+- CLI 新增 `alerts groups` 和 `alerts rule-details --ids`。
+- MCP 新增 `octo_alerts_groups_list` 和 `octo_alerts_rules_details_search`。

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ $ # 根因：resume 机制 + onFinish 回调 + 状态刷新形成无限循环
 
 可观测数据又多又杂：日志、链路、指标、告警、RUM、LLM Span、错误追踪、服务拓扑……分散在不同服务、不同环境、不同命名规则里。Agent 不知道「这个项目跑了哪些服务」「该查哪个环境」「上下游依赖是谁」，要么反复问你，要么瞎猜。
 
-octo-cli 的解法是三层结构：**上下文**（这个项目跑了什么、依赖谁、该查哪个环境）→ **技能**（查询语法、排障流程）→ **工具**（CLI 命令与 41 个 MCP 工具）。三层齐了，才是「Agent 会 grep 日志」和「Agent 能排查问题」之间的差距。
+octo-cli 的解法是三层结构：**上下文**（这个项目跑了什么、依赖谁、该查哪个环境）→ **技能**（查询语法、排障流程）→ **工具**（CLI 命令与 43 个 MCP 工具）。三层齐了，才是「Agent 会 grep 日志」和「Agent 能排查问题」之间的差距。
 
 <p align="center">
-  <img src="./assets/readme/architecture.svg" width="100%" alt="octo-cli 的三层结构。第一层上下文：记录项目跑了哪些服务、依赖什么、该查哪个环境，由 Agent 自动生成并保鲜，0 人工维护。第二层技能：7 个领域 Skill 提供查询语法和排障流程，让 Agent 知道怎么查。第三层工具：CLI 命令与 41 个 MCP 工具，Agent 有了前两层才能精准用对工具。">
+  <img src="./assets/readme/architecture.svg" width="100%" alt="octo-cli 的三层结构。第一层上下文：记录项目跑了哪些服务、依赖什么、该查哪个环境，由 Agent 自动生成并保鲜，0 人工维护。第二层技能：7 个领域 Skill 提供查询语法和排障流程，让 Agent 知道怎么查。第三层工具：CLI 命令与 43 个 MCP 工具，Agent 有了前两层才能精准用对工具。">
 </p>
 
 上下文文件不是手写的 —— Agent 通过**代码分析**（SDK 导入、服务配置）和**线上链路数据**（真实拓扑、入口、依赖）自动生成。链路数据反映的是生产环境实际在跑什么，比看代码靠谱。
@@ -140,6 +140,8 @@ octo-cli alerts detail <alertId>                          # 告警详情（含�
 octo-cli alerts timeseries <alertId> -l 1h                # 告警检测时序数据
 octo-cli alerts rules --group-id 123                      # 搜索告警规则
 octo-cli alerts rules -e online -p P0,P1                  # 按环境/优先级过滤规则
+octo-cli alerts groups                                    # 查询全部告警组
+octo-cli alerts rule-details --ids 101,102                # 批量查询规则详情（最多 100 个）
 octo-cli alerts create --file rule.json                   # 从 JSON 创建告警规则
 octo-cli alerts delete <ruleId>                           # 删除告警规则
 
@@ -228,6 +230,7 @@ octo-cli users alice bob                                  # 按姓名搜索用�
 | `logs search` / `logs aggregate` | 搜索日志 / 日志聚合 |
 | `alerts search` / `alerts rules` | 搜索告警 / 搜索告警规则 |
 | `alerts detail` / `alerts timeseries` | 告警详情 / 检测时序数据 |
+| `alerts groups` / `alerts rule-details` | 查询告警组 / 批量查询告警规则详情 |
 | `alerts create` / `alerts delete` | 从 JSON 创建 / 删除告警规则 |
 | `alerts silence` / `alerts unsilence` | 创建 / 解除告警静默（抑制单条告警通知） |
 | `alerts disable` / `alerts disables` / `alerts enable` | 停用规则 / 查看停用记录 / 删除停用记录 |
@@ -279,7 +282,7 @@ Agent 也是这么用的 —— 把输出 pipe 到 `jq` 做二次提取、pipe �
 
 ## MCP Server
 
-内置 stdio MCP Server，41 个工具，支持 Claude Code、Cursor 等 AI Agent 直接调用。
+内置 stdio MCP Server，43 个工具，支持 Claude Code、Cursor 等 AI Agent 直接调用。
 
 ```bash
 # 前提：已执行 octo-cli login
@@ -310,6 +313,7 @@ npx octo-cli mcp-install
 | `octo_logs_search` / `octo_logs_aggregate` | 搜索日志 / 日志聚合 |
 | `octo_alerts_search` / `octo_alerts_rules_search` | 搜索告警 / 搜索告警规则 |
 | `octo_alerts_detail` / `octo_alerts_timeseries` | 告警详情 / 检测时序数据 |
+| `octo_alerts_groups_list` / `octo_alerts_rules_details_search` | 查询告警组 / 批量查询告警规则详情 |
 | `octo_alerts_rules_create` / `octo_alerts_rules_delete` | 创建 / 删除告警规则 |
 | `octo_alerts_silence_create` / `octo_alerts_silence_delete` | 创建 / 解除告警静默（抑制单条告警通知） |
 | `octo_alerts_rule_disable_create` | 停用告警规则（规则本身不再检测） |
@@ -380,7 +384,7 @@ octo-cli 封装了 Octopus OpenAPI，默认地址 `https://octopus-app.zhenguany
 | 领域 | 接口 |
 |------|------|
 | 日志 | `/v1/logs/search`、`/v1/logs/aggregate` |
-| 告警 | `/v1/alerts/search`、`/v1/alert/rules/search`、`/v1/alert/rules`、`/v1/alerts/silences/*` |
+| 告警 | `/v1/alerts/search`、`/v1/alert/rules/search`、`/v1/alert/rules/groups`、`/v1/alert/rules/details/search`、`/v1/alert/rules`、`/v1/alerts/silences/*` |
 | Issue | `/v1/log-error-tracking/issues/*` |
 | Case | `/v1/cases/*`、`/v1/cases/groups/*` |
 | 链路 | `/v1/trace/span/list`、`/v1/trace/aggregate` |

--- a/assets/readme/architecture.svg
+++ b/assets/readme/architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 548" width="1200" height="548" role="img" aria-labelledby="archTitle archDesc">
   <title id="archTitle">octo-cli 的三层结构：上下文、技能、工具</title>
-  <desc id="archDesc">第一层上下文记录项目跑了哪些服务、依赖什么、该查哪个环境，由 Agent 自动生成并保鲜，无需人工维护。第二层是 7 个领域技能，提供查询语法和排障流程，让 Agent 知道怎么查。第三层是 CLI 命令与 41 个 MCP 工具，Agent 有了前两层才能精准用对工具。</desc>
+  <desc id="archDesc">第一层上下文记录项目跑了哪些服务、依赖什么、该查哪个环境，由 Agent 自动生成并保鲜，无需人工维护。第二层是 7 个领域技能，提供查询语法和排障流程，让 Agent 知道怎么查。第三层是 CLI 命令与 43 个 MCP 工具，Agent 有了前两层才能精准用对工具。</desc>
 
   <defs>
     <style>
@@ -75,7 +75,7 @@
     <text class="sans" x="300" y="484" font-size="20" fill="#3fb950">→ 有了上下文和技能，才能<tspan font-weight="600">精准用对工具</tspan></text>
 
     <line x1="936" y1="396" x2="936" y2="496" stroke="#21262d" stroke-width="1"/>
-    <text class="mono" x="1112" y="446" font-size="52" font-weight="700" fill="#3fb950" text-anchor="end">41</text>
+    <text class="mono" x="1112" y="446" font-size="52" font-weight="700" fill="#3fb950" text-anchor="end">43</text>
     <text class="sans" x="1112" y="474" font-size="18" fill="#6e7681" text-anchor="end">个 MCP 工具</text>
   </g>
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -240,6 +240,8 @@ npx octo-cli alerts timeseries 12345 --condition-id 0 -l 2h    # specific condit
 npx octo-cli alerts rules --group-id -1                        # all rules
 npx octo-cli alerts rules --search "error" --page 1 --page-size 10
 npx octo-cli alerts rules -e online -p P0,P1                   # filter by env/priority
+npx octo-cli alerts groups                                     # all alert groups
+npx octo-cli alerts rule-details --ids 101,102                 # full details, up to 100 rule IDs
 
 # Silence — mutes notifications for ONE firing alert (needs --alert-id)
 npx octo-cli alerts silence --rule-id 123 --alert-id 456 --duration 2h

--- a/skills/octopus-openapi/SKILL.md
+++ b/skills/octopus-openapi/SKILL.md
@@ -509,29 +509,42 @@ Case 返回结构与 `infra-octopus-rest` 的 Case API 保持一致；OpenAPI �
 
 > ⚠️ 环境和优先级的字段名是**复数数组** `envs` / `priorities`。传单数的 `env` / `priority` 会被后端**静默忽略**，返回未经过滤的结果——不会报错，所以很容易误判。
 
-### 8.3 创建告警规则 `POST /infra-octopus-openapi/v1/alert/rules`
+### 8.3 查询全部告警组 `GET /infra-octopus-openapi/v1/alert/rules/groups`
+
+返回当前租户的全部未删除告警组，字段为 `groupId`、`groupName`、`author`。接口保持服务层返回顺序，客户端不应自行排序。
+
+### 8.4 批量查询告警规则详情 `POST /infra-octopus-openapi/v1/alert/rules/details/search`
+
+请求体为 `{ "ruleIds": [101, 102] }`。`ruleIds` 必须非空、每项为正整数，单次最多 100 个。
+
+- 重复 ID 按首次出现位置去重，响应顺序与首次出现顺序一致。
+- 不存在、已删除或不属于当前租户的规则不会出现在响应中。
+- 支持 LOG、METRIC、ISSUE、RUM、LLM 规则。
+- 响应字段包括 `id`、`name`、`version`、`priority`、`groupId`、`groupName`、`env`、`service`、`ruleType`、`conditions`、`conditionEvaluationType`、`notice`、`tags`、`ruleTemplateId`、`activationStatus`、`createTime`、`updateTime`、`checkInterval`、`delayCheck`、`escalationPolicyId`。
+
+### 8.5 创建告警规则 `POST /infra-octopus-openapi/v1/alert/rules`
 
 Body 为规则 **数组**；字段含 `name`、`env`、`priority`、`ruleType`（log/metric/issue）、`conditions`、`conditionEvaluationType`（single/and/or）、`notice`、`groupId`、`tags`、`active` 等（结构复杂，以官方文档中的完整 JSON 为准）。
 
-### 8.4 删除告警规则 `DELETE /infra-octopus-openapi/v1/alert/rules`
+### 8.6 删除告警规则 `DELETE /infra-octopus-openapi/v1/alert/rules`
 
 请求体含待删 **`ruleId`**（以线上实际为准：亦有文档写作 `ruleIds` 列表，集成时请对照 Swagger）。
 
-### 8.5 告警静默 `POST /infra-octopus-openapi/v1/alerts/silences/create`
+### 8.7 告警静默 `POST /infra-octopus-openapi/v1/alerts/silences/create`
 
 `ruleId`、`alertId`、`startTime`、`endTime`、`scope`、`specifyGroups`、`silentlyNotify`。
 
 > ⚠️ `scope` 必须小写：`all` 或 `specify`。传大写 `ALL` / `SPECIFY` 会被拒绝，返回 `400 code=-14「静默范围不能为空」`。
 
-### 8.6 删除静默 `DELETE /infra-octopus-openapi/v1/alerts/silences/{ruleId}`
+### 8.8 删除静默 `DELETE /infra-octopus-openapi/v1/alerts/silences/{ruleId}`
 
-### 8.7 告警详情 `GET /infra-octopus-openapi/v1/alerts/{id}`
+### 8.9 告警详情 `GET /infra-octopus-openapi/v1/alerts/{id}`
 
 返回告警基本信息、规则条件（含查询表达式和阈值）及触发维度组合。
 
 响应字段：`id`、`title`、`priority`、`status`、`env`、`scope`、`alertRuleType`、`activeTime`、`duration`、`tags`、`description`、`rule`（含 `id`、`name`、`conditionEvaluationType`、`conditions`）、`activeMergedGroup`。
 
-### 8.8 告警检测时序数据 `GET /infra-octopus-openapi/v1/alerts/{id}/timeseries`
+### 8.10 告警检测时序数据 `GET /infra-octopus-openapi/v1/alerts/{id}/timeseries`
 
 返回告警对应的检测时序数据（时间点、值、标签、条件状态），供分析告警触发趋势使用。
 
@@ -539,7 +552,7 @@ Body 为规则 **数组**；字段含 `name`、`env`、`priority`、`ruleType`�
 
 > ⚠️ 这是目前唯一带 query string 的 GET 接口。签名时 **path 与 query 必须分开传**，且 query 需按 key 字母序排列（如 `conditionId=0&from=...&to=...`）。把整串 `path?query` 当作 path 去签会返回 `401 Signature error`。
 
-### 8.9 告警规则停用
+### 8.11 告警规则停用
 
 停用（disable）作用于**规则本身**，让它在指定时间段内不参与检测；静默（silence）只抑制某条已触发告警的通知，且必须带 `alertId`。两者是不同机制。
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -82,6 +82,49 @@ describe('OctoClient alert methods', () => {
     vi.restoreAllMocks();
   });
 
+  it('alertGroupsList gets all alert groups without a body', async () => {
+    const calls = captureFetch();
+    await client.alertGroupsList();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/alert/rules/groups'
+    );
+    expect(calls[0].body).toBe('');
+    vi.restoreAllMocks();
+  });
+
+  it('alertRuleDetailsSearch preserves requested IDs in the POST body', async () => {
+    const calls = captureFetch();
+    await client.alertRuleDetailsSearch([2, 1, 2]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/alert/rules/details/search'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({ ruleIds: [2, 1, 2] });
+    vi.restoreAllMocks();
+  });
+
+  it('alertRuleDetailsSearch rejects invalid batches before the request', async () => {
+    const calls = captureFetch();
+
+    await expect(client.alertRuleDetailsSearch([])).rejects.toThrow(
+      'At least one alert rule ID is required'
+    );
+    await expect(
+      client.alertRuleDetailsSearch(Array.from({ length: 101 }, () => 1))
+    ).rejects.toThrow('At most 100 alert rule IDs can be queried at once');
+    await expect(client.alertRuleDetailsSearch([1, 0])).rejects.toThrow(
+      'Alert rule IDs must be positive integers'
+    );
+
+    expect(calls).toHaveLength(0);
+    vi.restoreAllMocks();
+  });
+
   it('every request carries an octo-cli User-Agent', async () => {
     const calls = captureFetch();
     await client.alertRulesDelete(1);

--- a/src/client.ts
+++ b/src/client.ts
@@ -215,6 +215,28 @@ export class OctoClient {
     return this.post('/infra-octopus-openapi/v1/alert/rules/search', params);
   }
 
+  async alertGroupsList() {
+    return this.get('/infra-octopus-openapi/v1/alert/rules/groups');
+  }
+
+  async alertRuleDetailsSearch(ruleIds: number[]) {
+    if (!Array.isArray(ruleIds) || ruleIds.length === 0) {
+      throw new Error('At least one alert rule ID is required');
+    }
+    if (ruleIds.length > 100) {
+      throw new Error('At most 100 alert rule IDs can be queried at once');
+    }
+    if (
+      ruleIds.some((ruleId) => !Number.isSafeInteger(ruleId) || ruleId <= 0)
+    ) {
+      throw new Error('Alert rule IDs must be positive integers');
+    }
+
+    return this.post('/infra-octopus-openapi/v1/alert/rules/details/search', {
+      ruleIds,
+    });
+  }
+
   async alertRulesCreate(rules: unknown[]) {
     return this.post('/infra-octopus-openapi/v1/alert/rules', rules);
   }

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -353,6 +353,57 @@ describe('commands', () => {
       expect(body.priority).toBeUndefined();
     });
 
+    it('groups lists alert groups without reordering the response', async () => {
+      const groups = [
+        { groupId: 2, groupName: '综合组', author: 'user2' },
+        { groupId: 1, groupName: '阿里组', author: 'user1' },
+      ];
+      const { calls, stdout, program } = setupCli(groups);
+
+      await program.parseAsync(['node', 'octo', 'alerts', 'groups'], {
+        from: 'node',
+      });
+
+      expect(calls[0].method).toBe('GET');
+      expect(calls[0].url).toBe(
+        'https://example.com/infra-octopus-openapi/v1/alert/rules/groups'
+      );
+      expect(JSON.parse(stdout[0])).toEqual(groups);
+    });
+
+    it('rule-details queries comma-separated IDs and keeps duplicates', async () => {
+      const details = [
+        { id: 2, name: 'rule-2' },
+        { id: 1, name: 'rule-1' },
+      ];
+      const { calls, stdout, program } = setupCli(details);
+
+      await program.parseAsync(
+        ['node', 'octo', 'alerts', 'rule-details', '--ids', '2, 1,2'],
+        { from: 'node' }
+      );
+
+      expect(calls[0].method).toBe('POST');
+      expect(calls[0].url).toBe(
+        'https://example.com/infra-octopus-openapi/v1/alert/rules/details/search'
+      );
+      expect(JSON.parse(calls[0].body)).toEqual({ ruleIds: [2, 1, 2] });
+      expect(JSON.parse(stdout[0])).toEqual(details);
+    });
+
+    it('rule-details rejects invalid IDs before calling the API', async () => {
+      const { calls, program } = setupCli([]);
+
+      await expect(
+        program.parseAsync(
+          ['node', 'octo', 'alerts', 'rule-details', '--ids', '1,not-a-number'],
+          { from: 'node' }
+        )
+      ).rejects.toThrow('Alert rule IDs must be positive integers');
+
+      expect(calls).toHaveLength(0);
+    });
+
     it('search omits status entirely when not given', async () => {
       const { calls, program } = setupCli([]);
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -422,6 +422,33 @@ export function registerCommands(program: Command): void {
     });
 
   alerts
+    .command('groups')
+    .description('List all alert groups')
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (opts) => {
+      const client = getClient();
+      const data = await client.alertGroupsList();
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  alerts
+    .command('rule-details')
+    .description('Get alert rule details by IDs')
+    .requiredOption(
+      '--ids <ids>',
+      'Comma-separated alert rule IDs (1-100 positive integers)'
+    )
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (opts) => {
+      const ruleIds = opts.ids
+        .split(',')
+        .map((id: string) => Number(id.trim()));
+      const client = getClient();
+      const data = await client.alertRuleDetailsSearch(ruleIds);
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  alerts
     .command('silence')
     .description('Create alert silence')
     .requiredOption('--rule-id <id>', 'Alert rule ID')

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -433,6 +433,70 @@ describe('MCP tools', () => {
     });
   });
 
+  describe('alert rule query tools', () => {
+    it('exposes group list and batch detail schemas', () => {
+      const tools = getMcpTools();
+      const toolNames = tools.map((tool) => tool.name);
+
+      expect(toolNames).toEqual(
+        expect.arrayContaining([
+          'octo_alerts_groups_list',
+          'octo_alerts_rules_details_search',
+        ])
+      );
+
+      const detailsTool = tools.find(
+        (tool) => tool.name === 'octo_alerts_rules_details_search'
+      );
+      const ruleIds = detailsTool?.inputSchema.properties.ruleIds as {
+        minItems: number;
+        maxItems: number;
+        items: { type: string; minimum: number };
+      };
+      expect(detailsTool?.inputSchema.required).toEqual(['ruleIds']);
+      expect(ruleIds).toMatchObject({
+        minItems: 1,
+        maxItems: 100,
+        items: { type: 'integer', minimum: 1 },
+      });
+    });
+
+    it('lists groups and searches rule details through the matching endpoints', async () => {
+      const calls = captureFetch([]);
+      const client = testClient();
+
+      await handleMcpTool('octo_alerts_groups_list', {}, client);
+      await handleMcpTool(
+        'octo_alerts_rules_details_search',
+        { ruleIds: [2, 1, 2] },
+        client
+      );
+
+      expect(calls[0].method).toBe('GET');
+      expect(calls[0].url).toBe(
+        'https://example.com/infra-octopus-openapi/v1/alert/rules/groups'
+      );
+      expect(calls[1].method).toBe('POST');
+      expect(calls[1].url).toBe(
+        'https://example.com/infra-octopus-openapi/v1/alert/rules/details/search'
+      );
+      expect(JSON.parse(calls[1].body)).toEqual({ ruleIds: [2, 1, 2] });
+    });
+
+    it('rejects an empty detail batch before calling the API', async () => {
+      const calls = captureFetch();
+
+      const result = await handleMcpTool(
+        'octo_alerts_rules_details_search',
+        { ruleIds: [] },
+        testClient()
+      );
+
+      expect('isError' in result && result.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
   describe('alert rule disables', () => {
     it('exposes the three disable tools', () => {
       const toolNames = getMcpTools().map((tool) => tool.name);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -404,6 +404,35 @@ export function getMcpTools() {
       },
     },
     {
+      name: 'octo_alerts_groups_list',
+      description:
+        'List all Octopus alert groups for the current tenant. Returns groupId, groupName, and author in service order.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {},
+      },
+    },
+    {
+      name: 'octo_alerts_rules_details_search',
+      description:
+        'Get full details for up to 100 Octopus alert rules by ID. ' +
+        'Duplicate IDs are de-duplicated by first occurrence; missing, deleted, or inaccessible rules are omitted.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          ruleIds: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 100,
+            items: { type: 'integer', minimum: 1 },
+            description:
+              'Alert rule IDs. Response order follows the first occurrence of each requested ID.',
+          },
+        },
+        required: ['ruleIds'],
+      },
+    },
+    {
       name: 'octo_alerts_rules_create',
       description:
         'Create Octopus alert rules. Accepts an array of rule objects. ' +
@@ -1183,6 +1212,18 @@ export async function handleMcpTool(
             pageSize: (args.pageSize as number) ?? 20,
           },
         });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_groups_list': {
+        const data = await client.alertGroupsList();
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_alerts_rules_details_search': {
+        const data = await client.alertRuleDetailsSearch(
+          args.ruleIds as number[]
+        );
         return ok(JSON.stringify(data, null, 2));
       }
 


### PR DESCRIPTION
## 变更内容

- CLI 新增 `alerts groups`，查询当前租户全部告警组
- CLI 新增 `alerts rule-details --ids`，批量查询最多 100 条告警规则详情
- MCP 新增 `octo_alerts_groups_list` 和 `octo_alerts_rules_details_search`
- 在 Client 统一校验 ID 列表非空、最多 100 个且均为正整数
- 同步 README、内置 Skill、MCP 工具数量和 minor changeset

## 后端契约

对齐 [infra-octopus!4461](https://gitlab-ee.zhenguanyu.com/yuanli/infra-octopus/-/merge_requests/4461)：

- `GET /infra-octopus-openapi/v1/alert/rules/groups`
- `POST /infra-octopus-openapi/v1/alert/rules/details/search`
- 重复 ID 保留在请求中，由后端按首次出现顺序去重；缺失或无权限规则不会返回占位项

## 验证

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`（106 tests passed）
- `pnpm build`