### PR TITLE
feat: support issue merge

### DIFF
--- a/.changeset/calm-issues-merge.md
+++ b/.changeset/calm-issues-merge.md
@@ -1,0 +1,8 @@
+---
+'octo-cli': minor
+---
+
+Add Issue merge management to the CLI and MCP server.
+
+- Add CLI commands to merge Issues, unmerge children, and query merge relationships.
+- Add corresponding MCP tools and OpenAPI client support for log and RUM Issues.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ octo-cli issues search --status unresolved -l 1h         # 未解决的 Issue
 octo-cli issues detail <issueId>                          # Issue 详情
 octo-cli issues assign --user 123 --ids id1,id2          # 分配 Issue
 octo-cli issues update --ids id1,id2 -s resolved          # 解决 Issue
+octo-cli issues merge --ids id1,id2                       # 合并 Issue，返回 mergeIssueId
+octo-cli issues merge-children <issueId>                  # 查询 children 或 canonical parent
+octo-cli issues unmerge <mergeIssueId> --ids child1       # 移出 child，可能触发 dissolve
 octo-cli issues update --ids id1,id2 -s ignored \
   --ignore-type TIME \
   --ignore-end-time 2026-07-31T23:59:59Z              # 忽略到指定时间
@@ -236,6 +239,7 @@ octo-cli users alice bob                                  # 按姓名搜索用�
 | `alerts disable` / `alerts disables` / `alerts enable` | 停用规则 / 查看停用记录 / 删除停用记录 |
 | `issues search` / `issues detail` | 搜索 Issue / Issue 详情 |
 | `issues assign` / `issues update` | 批量分配 / 批量更新 Issue 状态 |
+| `issues merge` / `issues unmerge` / `issues merge-children` | 合并 / 移出 child / 查询合并关系 |
 | `cases list` / `cases create` | 查询 / 创建 Case |
 | `cases detail` / `cases detail-key` | Case 详情 |
 | `cases update` / `cases delete` | 更新或删除 Case |
@@ -320,6 +324,8 @@ npx octo-cli mcp-install
 | `octo_alerts_rule_disable_list` / `octo_alerts_rule_disable_delete` | 查看 / 删除停用记录 |
 | `octo_issues_search` / `octo_issues_detail` | 搜索 Issue / Issue 详情 |
 | `octo_issues_assign` / `octo_issues_update` | 批量分配 / 批量更新 Issue |
+| `octo_issues_merge` / `octo_issues_unmerge` | 合并 Issue / 从 merge Issue 移出 child |
+| `octo_issues_merge_children` | 查询 merge children 或 frozen child 的 canonical parent |
 | `octo_cases_list` / `octo_cases_create` | 查询 / 创建 Case |
 | `octo_cases_detail` / `octo_cases_detail_by_key` | Case 详情 |
 | `octo_cases_update` / `octo_cases_delete` | 更新或删除 Case |
@@ -385,7 +391,7 @@ octo-cli 封装了 Octopus OpenAPI，默认地址 `https://octopus-app.zhenguany
 |------|------|
 | 日志 | `/v1/logs/search`、`/v1/logs/aggregate` |
 | 告警 | `/v1/alerts/search`、`/v1/alert/rules/search`、`/v1/alert/rules/groups`、`/v1/alert/rules/details/search`、`/v1/alert/rules`、`/v1/alerts/silences/*` |
-| Issue | `/v1/log-error-tracking/issues/*` |
+| Issue | `/v1/log-error-tracking/issues/*`（含 merge / unmerge / merge-children） |
 | Case | `/v1/cases/*`、`/v1/cases/groups/*` |
 | 链路 | `/v1/trace/span/list`、`/v1/trace/aggregate` |
 | 指标 | `/v1/metrics/query/timeseries`、`/v1/metrics/query/queryMetric` |

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -267,6 +267,9 @@ npx octo-cli issues detail <issueId>
 # Manage
 npx octo-cli issues assign --user 123 --ids id1,id2
 npx octo-cli issues update --ids id1,id2 -s resolved
+npx octo-cli issues merge --ids id1,id2
+npx octo-cli issues merge-children <issueId>
+npx octo-cli issues unmerge <mergeIssueId> --ids child1
 ```
 
 ### Cases

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { normalizeAlertScope, OctoClient } from './client.js';
 
 // Intercept fetch to capture request details
@@ -367,6 +367,71 @@ describe('OctoClient alert methods', () => {
       'https://example.com/infra-octopus-openapi/v1/alert/rules/disables/1001'
     );
     vi.restoreAllMocks();
+  });
+});
+
+describe('OctoClient issue merge methods', () => {
+  const client = new OctoClient('https://example.com', {
+    token: 'test-token',
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls merge, unmerge, and merge-children OpenAPI endpoints', async () => {
+    const calls = captureFetch();
+
+    await client.issuesMerge({
+      issueIds: [' child-1 ', 'child-1', 'child-2'],
+    });
+    await client.issuesUnmerge({
+      mergeIssueId: 'merge-1',
+      childIssueIds: ['child-1', 'child-1'],
+      dataSource: 'rum',
+    });
+    await client.issueMergeChildren('child-1', 'rum');
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/merge'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      issueIds: ['child-1', 'child-2'],
+      dataSource: 'log',
+    });
+    expect(calls[1].method).toBe('POST');
+    expect(calls[1].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/unmerge'
+    );
+    expect(JSON.parse(calls[1].body)).toEqual({
+      mergeIssueId: 'merge-1',
+      childIssueIds: ['child-1'],
+      dataSource: 'rum',
+    });
+    expect(calls[2].method).toBe('GET');
+    expect(calls[2].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/child-1/merge-children?dataSource=rum'
+    );
+  });
+
+  it('rejects invalid merge inputs before sending a request', async () => {
+    const calls = captureFetch();
+
+    await expect(
+      client.issuesMerge({ issueIds: ['child-1', ' child-1 '] })
+    ).rejects.toThrow('At least two distinct Issue IDs are required');
+    await expect(
+      client.issuesUnmerge({ mergeIssueId: ' ', childIssueIds: ['child-1'] })
+    ).rejects.toThrow('mergeIssueId must not be blank');
+    await expect(
+      client.issuesUnmerge({ mergeIssueId: 'merge-1', childIssueIds: [] })
+    ).rejects.toThrow('At least one child Issue ID is required');
+    await expect(
+      client.issueMergeChildren('child-1', 'metric')
+    ).rejects.toThrow('Issue data source must be one of: log, rum');
+
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,6 +65,39 @@ export type AlertScope = 'all' | 'specify';
 
 export const ALERT_SCOPES: readonly AlertScope[] = ['all', 'specify'];
 
+function normalizeIssueDataSource(
+  dataSource: string | undefined
+): 'log' | 'rum' {
+  const normalized = dataSource ?? 'log';
+  if (normalized === 'log' || normalized === 'rum') return normalized;
+  throw new Error('Issue data source must be one of: log, rum');
+}
+
+function normalizeIssueIds(
+  issueIds: string[],
+  minimum: number,
+  minimumErrorMessage: string
+): string[] {
+  if (!Array.isArray(issueIds)) {
+    throw new Error('Issue IDs must be an array');
+  }
+  const normalized = issueIds.map((issueId) => String(issueId).trim());
+  if (normalized.some((issueId) => !issueId)) {
+    throw new Error('Issue IDs must not contain blank values');
+  }
+  const distinct = [...new Set(normalized)];
+  if (distinct.length < minimum) {
+    throw new Error(minimumErrorMessage);
+  }
+  return distinct;
+}
+
+function normalizeIssueId(issueId: string, fieldName: string): string {
+  const normalized = String(issueId ?? '').trim();
+  if (!normalized) throw new Error(`${fieldName} must not be blank`);
+  return normalized;
+}
+
 /**
  * Accepts the legacy uppercase spelling that older versions of this CLI sent,
  * so `--scope ALL` keeps working instead of failing with "静默范围不能为空".
@@ -360,6 +393,47 @@ export class OctoClient {
     return this.put(
       '/infra-octopus-openapi/v1/log-error-tracking/issues/batch-update',
       params
+    );
+  }
+
+  async issuesMerge(params: { issueIds: string[]; dataSource?: string }) {
+    return this.post(
+      '/infra-octopus-openapi/v1/log-error-tracking/issues/merge',
+      {
+        issueIds: normalizeIssueIds(
+          params.issueIds,
+          2,
+          'At least two distinct Issue IDs are required'
+        ),
+        dataSource: normalizeIssueDataSource(params.dataSource),
+      }
+    );
+  }
+
+  async issuesUnmerge(params: {
+    mergeIssueId: string;
+    childIssueIds: string[];
+    dataSource?: string;
+  }): Promise<{ mergeIssueExists: boolean }> {
+    return this.post<{ mergeIssueExists: boolean }>(
+      '/infra-octopus-openapi/v1/log-error-tracking/issues/unmerge',
+      {
+        mergeIssueId: normalizeIssueId(params.mergeIssueId, 'mergeIssueId'),
+        childIssueIds: normalizeIssueIds(
+          params.childIssueIds,
+          1,
+          'At least one child Issue ID is required'
+        ),
+        dataSource: normalizeIssueDataSource(params.dataSource),
+      }
+    );
+  }
+
+  async issueMergeChildren(issueId: string, dataSource?: string) {
+    const normalizedIssueId = normalizeIssueId(issueId, 'issueId');
+    const normalizedDataSource = normalizeIssueDataSource(dataSource);
+    return this.get(
+      `/infra-octopus-openapi/v1/log-error-tracking/issues/${encodeURIComponent(normalizedIssueId)}/merge-children?dataSource=${normalizedDataSource}`
     );
   }
 

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -90,6 +90,108 @@ describe('commands', () => {
     expect(logs).toContain('Issues updated');
   });
 
+  it('issues merge lifecycle commands call OpenAPI and print JSON', async () => {
+    vi.stubEnv('OCTOPUS_TOKEN', 'test-token');
+    vi.stubEnv('OCTOPUS_BASE_URL', 'https://example.com');
+    const calls: { url: string; method: string; body: string }[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init: RequestInit) => {
+        calls.push({
+          url,
+          method: init.method ?? 'GET',
+          body: String(init.body ?? ''),
+        });
+        const data = url.endsWith('/merge')
+          ? { mergeIssueId: 'merge-1' }
+          : url.endsWith('/unmerge')
+            ? { mergeIssueExists: false }
+            : { children: [], canonicalIssueId: 'merge-1' };
+        return new Response(JSON.stringify({ code: 0, data, message: 'ok' }));
+      })
+    );
+    const logs: string[] = [];
+    const errors: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      logs.push(String(message));
+    });
+    vi.spyOn(console, 'error').mockImplementation((message?: unknown) => {
+      errors.push(String(message));
+    });
+
+    const run = async (args: string[]) => {
+      const program = new Command();
+      program.exitOverride();
+      registerCommands(program);
+      await program.parseAsync(['node', 'octo', ...args], { from: 'node' });
+    };
+
+    await run(['issues', 'merge', '--ids', 'child-1,child-2']);
+    await run([
+      'issues',
+      'unmerge',
+      'merge-1',
+      '--ids',
+      'child-1',
+      '--source',
+      'rum',
+    ]);
+    await run(['issues', 'merge-children', 'child-1']);
+
+    expect(calls[0].method).toBe('POST');
+    expect(JSON.parse(calls[0].body)).toEqual({
+      issueIds: ['child-1', 'child-2'],
+      dataSource: 'log',
+    });
+    expect(JSON.parse(calls[1].body)).toEqual({
+      mergeIssueId: 'merge-1',
+      childIssueIds: ['child-1'],
+      dataSource: 'rum',
+    });
+    expect(calls[2].method).toBe('GET');
+    expect(calls[2].url).toContain(
+      '/issues/child-1/merge-children?dataSource=log'
+    );
+    expect(JSON.parse(logs[0])).toEqual({ mergeIssueId: 'merge-1' });
+    expect(JSON.parse(logs[1])).toEqual({ mergeIssueExists: false });
+    expect(errors).toContain(
+      'The merge Issue was automatically dissolved because fewer than two children remain'
+    );
+  });
+
+  it('issues unmerge does not print a dissolve warning when the parent remains', async () => {
+    vi.stubEnv('OCTOPUS_TOKEN', 'test-token');
+    vi.stubEnv('OCTOPUS_BASE_URL', 'https://example.com');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            code: 0,
+            data: { mergeIssueExists: true },
+            message: 'ok',
+          })
+        );
+      })
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const errors: string[] = [];
+    vi.spyOn(console, 'error').mockImplementation((message?: unknown) => {
+      errors.push(String(message));
+    });
+
+    const program = new Command();
+    program.exitOverride();
+    registerCommands(program);
+
+    await program.parseAsync(
+      ['node', 'octo', 'issues', 'unmerge', 'merge-1', '--ids', 'child-1'],
+      { from: 'node' }
+    );
+
+    expect(errors).toHaveLength(0);
+  });
+
   it('issues update rejects USER_COUNT without userField for log source', async () => {
     vi.stubEnv('OCTOPUS_TOKEN', 'test-token');
     vi.stubEnv('OCTOPUS_BASE_URL', 'https://example.com');

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -719,6 +719,70 @@ export function registerCommands(program: Command): void {
       console.log('Issues updated');
     });
 
+  issues
+    .command('merge')
+    .description('Merge issues and return the canonical merge Issue ID')
+    .requiredOption('--ids <ids>', 'Comma-separated issue IDs')
+    .option(
+      '--source <src>',
+      'Data source: log or rum',
+      parseIssueSource,
+      'log'
+    )
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (opts) => {
+      const client = getClient();
+      const data = await client.issuesMerge({
+        issueIds: opts.ids.split(','),
+        dataSource: opts.source,
+      });
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  issues
+    .command('unmerge')
+    .description('Remove child issues from a merge Issue')
+    .argument('<mergeIssueId>', 'Merge Issue ID')
+    .requiredOption('--ids <ids>', 'Comma-separated child Issue IDs')
+    .option(
+      '--source <src>',
+      'Data source: log or rum',
+      parseIssueSource,
+      'log'
+    )
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (mergeIssueId, opts) => {
+      const client = getClient();
+      const data = await client.issuesUnmerge({
+        mergeIssueId,
+        childIssueIds: opts.ids.split(','),
+        dataSource: opts.source,
+      });
+      if (!data.mergeIssueExists) {
+        console.error(
+          'The merge Issue was automatically dissolved because fewer than two children remain'
+        );
+      }
+      printOutput(data, opts.output as OutputFormat);
+    });
+
+  issues
+    .command('merge-children')
+    .description('Get merge children or the canonical parent of a frozen child')
+    .argument('<issueId>', 'Issue ID')
+    .option(
+      '--source <src>',
+      'Data source: log or rum',
+      parseIssueSource,
+      'log'
+    )
+    .option('-o, --output <fmt>', 'Output format', 'json')
+    .action(async (issueId, opts) => {
+      const client = getClient();
+      const data = await client.issueMergeChildren(issueId, opts.source);
+      printOutput(data, opts.output as OutputFormat);
+    });
+
   // ─── cases ───────────────────────────────────────────────
   const cases = program.command('cases').description('Case operations');
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -44,6 +44,9 @@ describe('MCP tools', () => {
         'octo_issues_detail',
         'octo_issues_assign',
         'octo_issues_update',
+        'octo_issues_merge',
+        'octo_issues_unmerge',
+        'octo_issues_merge_children',
         'octo_trace_aggregate',
         'octo_metrics_point',
         'octo_services_entries',
@@ -101,6 +104,72 @@ describe('MCP tools', () => {
       issueIds: ['ISSUE-1'],
       status: 'resolved',
     });
+  });
+
+  it('dispatches the issue merge lifecycle tools', async () => {
+    const client = testClient();
+    const calls = captureFetch({ mergeIssueId: 'merge-1' });
+
+    const mergeResult = await handleMcpTool(
+      'octo_issues_merge',
+      { issueIds: ['child-1', 'child-2'] },
+      client
+    );
+    await handleMcpTool(
+      'octo_issues_unmerge',
+      {
+        mergeIssueId: 'merge-1',
+        childIssueIds: ['child-1'],
+        dataSource: 'rum',
+      },
+      client
+    );
+    await handleMcpTool(
+      'octo_issues_merge_children',
+      { issueId: 'child-1' },
+      client
+    );
+
+    expect(mergeResult.content[0].text).toContain('"mergeIssueId": "merge-1"');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/merge'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      issueIds: ['child-1', 'child-2'],
+      dataSource: 'log',
+    });
+    expect(calls[1].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/unmerge'
+    );
+    expect(JSON.parse(calls[1].body)).toEqual({
+      mergeIssueId: 'merge-1',
+      childIssueIds: ['child-1'],
+      dataSource: 'rum',
+    });
+    expect(calls[2].method).toBe('GET');
+    expect(calls[2].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/log-error-tracking/issues/child-1/merge-children?dataSource=log'
+    );
+  });
+
+  it('rejects invalid issue merge tool inputs before HTTP', async () => {
+    const client = testClient();
+    const calls = captureFetch();
+
+    const mergeResult = await handleMcpTool(
+      'octo_issues_merge',
+      { issueIds: ['child-1', 'child-1'] },
+      client
+    );
+    const unmergeResult = await handleMcpTool(
+      'octo_issues_unmerge',
+      { mergeIssueId: 'merge-1', childIssueIds: [] },
+      client
+    );
+
+    expect(mergeResult.content[0]?.text).toContain('At least two');
+    expect(unmergeResult.content[0]?.text).toContain('At least one');
+    expect(calls).toHaveLength(0);
   });
 
   it('dispatches issue update with USER_COUNT ignoreRule', async () => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -750,6 +750,73 @@ export function getMcpTools() {
       },
     },
     {
+      name: 'octo_issues_merge',
+      description:
+        'Merge at least two distinct Octopus Issues. Returns the authoritative mergeIssueId; do not infer the parent from input order.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          issueIds: {
+            type: 'array',
+            minItems: 2,
+            items: { type: 'string', minLength: 1 },
+            description:
+              'Issue IDs to merge. Duplicates are removed in first-occurrence order.',
+          },
+          dataSource: {
+            type: 'string',
+            enum: ['log', 'rum'],
+            description: 'Data source: log or rum (default log)',
+          },
+        },
+        required: ['issueIds'],
+      },
+    },
+    {
+      name: 'octo_issues_unmerge',
+      description:
+        'Remove child Issues from a merge Issue. mergeIssueExists=false means the parent was automatically dissolved.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          mergeIssueId: {
+            type: 'string',
+            minLength: 1,
+            description: 'Merge Issue ID',
+          },
+          childIssueIds: {
+            type: 'array',
+            minItems: 1,
+            items: { type: 'string', minLength: 1 },
+            description: 'Child Issue IDs to remove',
+          },
+          dataSource: {
+            type: 'string',
+            enum: ['log', 'rum'],
+            description: 'Data source: log or rum (default log)',
+          },
+        },
+        required: ['mergeIssueId', 'childIssueIds'],
+      },
+    },
+    {
+      name: 'octo_issues_merge_children',
+      description:
+        'Get children of an active merge Issue, or canonicalIssueId when the queried Issue is a frozen child.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          issueId: { type: 'string', minLength: 1, description: 'Issue ID' },
+          dataSource: {
+            type: 'string',
+            enum: ['log', 'rum'],
+            description: 'Data source: log or rum (default log)',
+          },
+        },
+        required: ['issueId'],
+      },
+    },
+    {
       name: 'octo_cases_list',
       description:
         'List Octopus cases. Filter by group, status, priority, assignee, or case name input.',
@@ -1358,6 +1425,31 @@ export async function handleMcpTool(
           ignoreRule: validateIssueIgnoreRuleArgs(args),
         });
         return ok('Issues updated');
+      }
+
+      case 'octo_issues_merge': {
+        const data = await client.issuesMerge({
+          issueIds: args.issueIds as string[],
+          dataSource: args.dataSource as string | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_issues_unmerge': {
+        const data = await client.issuesUnmerge({
+          mergeIssueId: String(args.mergeIssueId ?? ''),
+          childIssueIds: args.childIssueIds as string[],
+          dataSource: args.dataSource as string | undefined,
+        });
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_issues_merge_children': {
+        const data = await client.issueMergeChildren(
+          String(args.issueId ?? ''),
+          args.dataSource as string | undefined
+        );
+        return ok(JSON.stringify(data, null, 2));
       }
 
       case 'octo_cases_list': {


### PR DESCRIPTION
## 改动说明

<!-- 简要描述这次 PR 干了什么、为什么 -->

- 新增 Issue 合并完整能力：issues merge、issues unmerge、issues merge-children。
- MCP 新增对应的 octo_issues_merge、octo_issues_unmerge、octo_issues_merge_children 三个工具。
- Client 层统一处理 ID 去重、空值校验、log/rum 数据源及路径编码。
- 补充 CLI、Client、MCP 测试和 README/Skill 文档。
## Checklist

- [x] 代码已通过 `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- [x] 已补齐必要的测试
- [x] 已运行 `pnpm changeset` 并提交 `.changeset/*.md`（纯文档/重构/测试可跳过）
- [x] README / CONTRIBUTING 相关文档已同步（如有必要）
