### PR TITLE
feat: add inspection report search to CLI and MCP

### DIFF
--- a/.changeset/inspection-report-search.md
+++ b/.changeset/inspection-report-search.md
@@ -1,0 +1,8 @@
+---
+'octo-cli': minor
+---
+
+新增巡检报告查询能力，CLI 与 MCP 双端可用。
+
+- 新增 `octo inspection reports` 命令，支持按关键词、任务 ID、任务组名、结果（normal/abnormal）和创建时间范围过滤，带分页与 json/table/jsonl 输出。
+- 新增 `octo_inspection_report_search` MCP 工具，供 AI Agent 查询巡检报告。

--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ octo-cli cases link <caseId> --type alert --target-id 123 # 关联告警
 octo-cli cases note <caseId> --text "已通知负责人"          # 添加备注
 ```
 
+### 巡检 (Inspection)
+
+```bash
+octo-cli inspection reports -q db                         # 按关键词搜索巡检报告
+octo-cli inspection reports --result abnormal -l 1d       # 近一天的异常报告
+octo-cli inspection reports --task-id 7 --page 2 -n 20    # 按任务 ID 翻页
+octo-cli inspection reports --task-group infra-db         # 按任务组名过滤
+```
+
 ### 链路 (Trace) / 指标 (Metrics)
 
 ```bash
@@ -253,6 +262,7 @@ octo-cli users alice bob                                  # 按姓名搜索用�
 | `cases link` / `cases unlink` | 关联或取消关联告警/Issue |
 | `cases note` / `cases note-update` | 添加或修改 Case 备注 |
 | `cases groups` / `cases group-create` | 查询或创建 Case 分组 |
+| `inspection reports` | 搜索巡检报告（关键词 / 任务 / 任务组 / 结果 / 时间范围过滤） |
 | `trace search` / `trace aggregate` | 搜索链路 Span / 链路聚合 |
 | `metrics query` / `metrics point` | 指标时序查询 / 单点查询 |
 | `services list` / `services entries` / `services topo` | 服务列表 / 入口列表 / 拓扑图 |
@@ -340,6 +350,7 @@ npx octo-cli mcp-install
 | `octo_cases_link` / `octo_cases_unlink` | 关联或取消关联告警/Issue |
 | `octo_cases_note_add` / `octo_cases_note_update` | 添加或修改 Case 备注 |
 | `octo_cases_groups_all` / `octo_cases_group_create` | 查询或创建 Case 分组 |
+| `octo_inspection_report_search` | 搜索巡检报告（关键词 / 任务 / 任务组 / 结果 / 时间范围过滤） |
 | `octo_trace_search` / `octo_trace_aggregate` | 搜索链路 Span / 链路聚合 |
 | `octo_metrics_query` / `octo_metrics_point` | 指标时序 / 单点查询 |
 | `octo_services_list` / `octo_services_entries` / `octo_services_topology` | 服务列表 / 入口 / 拓扑 |
@@ -401,6 +412,7 @@ octo-cli 封装了 Octopus OpenAPI，默认地址 `https://octopus-app.zhenguany
 | 告警 | `/v1/alerts/search`、`/v1/alert/rules/search`、`/v1/alert/rules/groups`、`/v1/alert/rules/details/search`、`/v1/alert/rules`、`/v1/alerts/silences/*` |
 | Issue | `/v1/log-error-tracking/issues/*`（含 ai-analysis / merge / unmerge / merge-children） |
 | Case | `/v1/cases/*`、`/v1/cases/groups/*` |
+| 巡检 | `/v1/inspection/reports/search` |
 | 链路 | `/v1/trace/span/list`、`/v1/trace/aggregate` |
 | 指标 | `/v1/metrics/query/timeseries`、`/v1/metrics/query/queryMetric` |
 | 服务 | `/v1/apm/query/*`、`/v1/apm/topology/*` |

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -296,6 +296,16 @@ npx octo-cli cases note <caseId> --text "owner notified"
 npx octo-cli cases groups
 ```
 
+### Inspection Reports
+
+```bash
+# Search inspection reports (keyword matches report or task name)
+npx octo-cli inspection reports -q db
+npx octo-cli inspection reports --result abnormal -l 1d          # abnormal reports in last day
+npx octo-cli inspection reports --task-id 7 --page 2 -n 20       # by task ID, paginated
+npx octo-cli inspection reports --task-group infra-db            # by task group (user-visible name, not ID)
+```
+
 ### Traces
 
 ```bash

--- a/skills/octopus-openapi/SKILL.md
+++ b/skills/octopus-openapi/SKILL.md
@@ -26,6 +26,7 @@ tags:
 | [指标](#五指标查询相关接口) | timeseries / queryMetric，及 [V2.0](#指标接口-v20) |
 | [错误追踪](#六错误追踪相关接口) | Issue 查询、详情、分布、分配、状态与 `ignoreRule` |
 | [Case](#七case-相关接口) | Case 列表、详情、创建更新、关系、备注、分组 |
+| [巡检](#巡检查询相关接口) | 巡检报告搜索 |
 | [告警](#八告警查询相关接口) | 告警查询、规则 CRUD、静默 |
 | [服务 APM](#九服务查询相关接口) | 入口/上下游/拓扑/时序等 |
 | [大盘](#十大盘相关接口) | 创建 / 更新大盘 |
@@ -641,6 +642,23 @@ Query 参数：`from`（必填，epoch ms）、`to`（必填，epoch ms）、`co
 ### Event 聚合 `POST /infra-octopus-openapi/v1/event/aggregate`
 
 请求使用 `aggregationField` 指定聚合字段与操作，使用 `groupFieldList` 指定分组字段、数量上限和排序方式。
+
+---
+
+## 巡检查询相关接口
+
+### 巡检报告搜索 `POST /infra-octopus-openapi/v1/inspection/reports/search`
+
+按条件搜索巡检报告，返回报告及其巡检项详情。请求字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `keyword` | string | 关键词，匹配报告名或任务名 |
+| `taskId` | number | 巡检任务 ID |
+| `taskGroupName` | string | 任务组名（用户可见名称，非 ID） |
+| `result` | string | 报告结果，`normal` 或 `abnormal` |
+| `startCreateTime` / `endCreateTime` | number | 创建时间范围（epoch 毫秒） |
+| `pageNo` / `pageSize` | number | 翻页，`pageSize` 默认 10、上限 50 |
 
 ---
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -802,3 +802,51 @@ describe('OctoClient case methods', () => {
     vi.restoreAllMocks();
   });
 });
+
+describe('OctoClient inspection methods', () => {
+  const client = new OctoClient('https://example.com', {
+    token: 'test-token',
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('inspectionReportsSearch posts filter and pagination fields', async () => {
+    const calls = captureFetch();
+    await client.inspectionReportsSearch({
+      pageNo: 2,
+      pageSize: 20,
+      keyword: 'db',
+      taskId: 7,
+      taskGroupName: 'infra-db',
+      result: 'abnormal',
+      startCreateTime: 1000,
+      endCreateTime: 2000,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(
+      'https://example.com/infra-octopus-openapi/v1/inspection/reports/search'
+    );
+    expect(JSON.parse(calls[0].body)).toEqual({
+      pageNo: 2,
+      pageSize: 20,
+      keyword: 'db',
+      taskId: 7,
+      taskGroupName: 'infra-db',
+      result: 'abnormal',
+      startCreateTime: 1000,
+      endCreateTime: 2000,
+    });
+  });
+
+  it('inspectionReportsSearch omits unset optional fields', async () => {
+    const calls = captureFetch();
+    await client.inspectionReportsSearch({ pageNo: 1, pageSize: 10 });
+
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0].body)).toEqual({ pageNo: 1, pageSize: 10 });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -533,6 +533,24 @@ export class OctoClient {
     return this.post('/infra-octopus-openapi/v1/cases/groups', params);
   }
 
+  // --- Inspection ---
+
+  async inspectionReportsSearch(params: {
+    pageNo: number;
+    pageSize: number;
+    keyword?: string;
+    taskId?: number;
+    taskGroupName?: string;
+    result?: string;
+    startCreateTime?: number;
+    endCreateTime?: number;
+  }) {
+    return this.post(
+      '/infra-octopus-openapi/v1/inspection/reports/search',
+      params
+    );
+  }
+
   // --- Trace ---
 
   async traceSpanList(params: {

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1041,4 +1041,83 @@ describe('commands', () => {
       expect(calls).toHaveLength(0);
     });
   });
+
+  describe('inspection reports', () => {
+    function setupCli() {
+      vi.stubEnv('OCTOPUS_TOKEN', 'test-token');
+      vi.stubEnv('OCTOPUS_BASE_URL', 'https://example.com');
+      const calls: { url: string; method: string; body: string }[] = [];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string, init: RequestInit) => {
+          calls.push({
+            url,
+            method: init.method ?? 'GET',
+            body: String(init.body ?? ''),
+          });
+          return new Response(
+            JSON.stringify({ code: 0, data: [], message: 'ok' })
+          );
+        })
+      );
+      vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const program = new Command();
+      program.exitOverride();
+      registerCommands(program);
+      return { calls, program };
+    }
+
+    it('reports forwards filters and pagination', async () => {
+      const { calls, program } = setupCli();
+
+      await program.parseAsync(
+        [
+          'node',
+          'octo',
+          'inspection',
+          'reports',
+          '--query',
+          'db',
+          '--task-id',
+          '7',
+          '--task-group',
+          'infra-db',
+          '--result',
+          'abnormal',
+          '--page',
+          '2',
+          '--limit',
+          '20',
+        ],
+        { from: 'node' }
+      );
+
+      expect(calls[0].method).toBe('POST');
+      expect(calls[0].url).toBe(
+        'https://example.com/infra-octopus-openapi/v1/inspection/reports/search'
+      );
+      expect(JSON.parse(calls[0].body)).toEqual({
+        pageNo: 2,
+        pageSize: 20,
+        keyword: 'db',
+        taskId: 7,
+        taskGroupName: 'infra-db',
+        result: 'abnormal',
+      });
+    });
+
+    it('reports defaults pagination and omits unset filters', async () => {
+      const { calls, program } = setupCli();
+
+      await program.parseAsync(['node', 'octo', 'inspection', 'reports'], {
+        from: 'node',
+      });
+
+      expect(calls[0].method).toBe('POST');
+      expect(JSON.parse(calls[0].body)).toEqual({
+        pageNo: 1,
+        pageSize: 10,
+      });
+    });
+  });
 });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1061,6 +1061,47 @@ export function registerCommands(program: Command): void {
       console.log('Case group created');
     });
 
+  // ─── inspection ──────────────────────────────────────────
+  const inspection = program
+    .command('inspection')
+    .description('Inspection report operations');
+
+  inspection
+    .command('reports')
+    .description('Search inspection reports')
+    .option(
+      '-q, --query <keyword>',
+      'Keyword matching report name or task name'
+    )
+    .option('--task-id <id>', 'Inspection task ID')
+    .option(
+      '--task-group <name>',
+      'Task group name (user-visible name, not ID)'
+    )
+    .option('-r, --result <result>', 'Report result: normal or abnormal')
+    .option('-l, --last <duration>', 'Time range, e.g. 15m, 1h, 2d')
+    .option('--from <time>', 'Create time start (epoch ms or ISO)')
+    .option('--to <time>', 'Create time end (epoch ms or ISO)')
+    .option('--page <n>', 'Page number', '1')
+    .option('-n, --limit <n>', 'Page size (default 10, max 50)', '10')
+    .option('-o, --output <fmt>', 'Output: json, table, jsonl', 'json')
+    .action(async (opts) => {
+      const client = getClient();
+      const range =
+        opts.last || opts.from || opts.to ? resolveTimeRange(opts) : undefined;
+      const data = await client.inspectionReportsSearch({
+        pageNo: Number.parseInt(opts.page, 10),
+        pageSize: Number.parseInt(opts.limit, 10),
+        keyword: opts.query,
+        taskId: opts.taskId ? Number.parseInt(opts.taskId, 10) : undefined,
+        taskGroupName: opts.taskGroup,
+        result: opts.result,
+        startCreateTime: range?.from,
+        endCreateTime: range?.to,
+      });
+      printOutput(data, opts.output as OutputFormat);
+    });
+
   // ─── trace ───────────────────────────────────────────────
   const trace = program.command('trace').description('Trace operations');
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -57,6 +57,7 @@ describe('MCP tools', () => {
         'octo_users_search',
         'octo_cases_create',
         'octo_cases_link',
+        'octo_inspection_report_search',
       ])
     );
     const metricsPoint = tools.find(
@@ -924,6 +925,56 @@ describe('MCP tools', () => {
       const body = JSON.parse(calls[0].body);
       expect(body.alertRuleType).toBe('metric');
       expect(body.pageNo).toBe(3);
+    });
+  });
+
+  describe('inspection report search tool', () => {
+    it('forwards filters and pagination', async () => {
+      const calls = captureFetch([]);
+
+      await handleMcpTool(
+        'octo_inspection_report_search',
+        {
+          keyword: 'db',
+          taskId: 7,
+          taskGroupName: 'infra-db',
+          result: 'abnormal',
+          startCreateTime: 1000,
+          endCreateTime: 2000,
+          limit: 20,
+          pageNo: 2,
+        },
+        testClient()
+      );
+
+      expect(calls[0].method).toBe('POST');
+      expect(calls[0].url).toBe(
+        'https://example.com/infra-octopus-openapi/v1/inspection/reports/search'
+      );
+      expect(JSON.parse(calls[0].body)).toEqual({
+        keyword: 'db',
+        taskId: 7,
+        taskGroupName: 'infra-db',
+        result: 'abnormal',
+        startCreateTime: 1000,
+        endCreateTime: 2000,
+        pageSize: 20,
+        pageNo: 2,
+      });
+    });
+
+    it('defaults pagination and caps page size at 50', async () => {
+      const calls = captureFetch([]);
+
+      await handleMcpTool(
+        'octo_inspection_report_search',
+        { limit: 200 },
+        testClient()
+      );
+
+      const body = JSON.parse(calls[0].body);
+      expect(body.pageNo).toBe(1);
+      expect(body.pageSize).toBe(50);
     });
   });
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1263,6 +1263,43 @@ export function getMcpTools() {
       },
     },
     {
+      name: 'octo_inspection_report_search',
+      description:
+        'Search Octopus inspection reports. Filter by keyword (report/task name), task ID, task group name, result (normal/abnormal), and create time range. Returns reports with their inspection item details.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          keyword: {
+            type: 'string',
+            description: 'Keyword matching report name or task name',
+          },
+          taskId: { type: 'number', description: 'Inspection task ID' },
+          taskGroupName: {
+            type: 'string',
+            description: 'Task group name (the user-visible name, not the ID)',
+          },
+          result: {
+            type: 'string',
+            description: 'Report result filter',
+            enum: ['normal', 'abnormal'],
+          },
+          startCreateTime: {
+            type: 'number',
+            description: 'Create time range start in epoch milliseconds',
+          },
+          endCreateTime: {
+            type: 'number',
+            description: 'Create time range end in epoch milliseconds',
+          },
+          limit: {
+            type: 'number',
+            description: 'Page size (default 10, max 50)',
+          },
+          pageNo: { type: 'number', description: 'Page number (default 1)' },
+        },
+      },
+    },
+    {
       name: 'octo_users_search',
       description: 'Search Octopus users by names.',
       inputSchema: {
@@ -1853,6 +1890,21 @@ export async function handleMcpTool(
 
       case 'octo_users_search': {
         const data = await client.usersSearch(args.names as string[]);
+        return ok(JSON.stringify(data, null, 2));
+      }
+
+      case 'octo_inspection_report_search': {
+        const rawLimit = args.limit as number | undefined;
+        const data = await client.inspectionReportsSearch({
+          pageNo: (args.pageNo as number) ?? 1,
+          pageSize: rawLimit ? Math.min(rawLimit, 50) : 10,
+          keyword: args.keyword as string | undefined,
+          taskId: args.taskId as number | undefined,
+          taskGroupName: args.taskGroupName as string | undefined,
+          result: args.result as string | undefined,
+          startCreateTime: args.startCreateTime as number | undefined,
+          endCreateTime: args.endCreateTime as number | undefined,
+        });
         return ok(JSON.stringify(data, null, 2));
       }
 


### PR DESCRIPTION
## 概述

新增巡检报告查询能力，CLI 与 MCP 双端可用，对接 infra-octopus OpenAPI 的巡检报告搜索接口。

## 变更内容

- **client**: 新增 `OctoClient.inspectionReportsSearch`，调用 `POST /infra-octopus-openapi/v1/inspection/reports/search`
- **CLI**: 新增 `octo inspection reports` 命令，支持关键词、任务 ID、任务组名、结果（normal/abnormal）、创建时间范围过滤，带分页与 json/table/jsonl 输出
- **MCP**: 新增 `octo_inspection_report_search` 工具，供 AI Agent 查询巡检报告（pageSize 默认 10、上限 50）
- **changeset**: minor bump

## 测试

- client / command / MCP 三层均补充 happy path + 边界 case 单测
- 提交前四项全绿：`pnpm typecheck && pnpm lint && pnpm test && pnpm build`（161 tests passed）